### PR TITLE
static data layer - improve bundling / build tooling

### DIFF
--- a/packages/common-ui/src/components/StudySession.vue
+++ b/packages/common-ui/src/components/StudySession.vue
@@ -308,7 +308,7 @@ export default defineComponent({
             .map(async (c) => await this.dataLayer.getClassroomDB(c.id, 'student'))
         );
 
-        sessionClassroomDBs.forEach((db) => {
+        sessionClassroomDBs.forEach((_db) => {
           // db.setChangeFcn(this.handleClassroomMessage());
         });
 
@@ -641,7 +641,9 @@ a {
 
 @keyframes varFade {
   0% {
-    box-shadow: rgba(var(--r), var(--g), 0, 0.25) 0px 7px 8px -4px, rgba(var(--r), var(--g), 0, 0.25) 0px 12px 17px 2px,
+    box-shadow:
+      rgba(var(--r), var(--g), 0, 0.25) 0px 7px 8px -4px,
+      rgba(var(--r), var(--g), 0, 0.25) 0px 12px 17px 2px,
       rgba(var(--r), var(--g), 0, 0.25) 0px 5px 22px 4px;
   }
   100% {
@@ -651,7 +653,9 @@ a {
 
 @keyframes greenFade {
   0% {
-    box-shadow: rgba(0, 150, 0, 0.25) 0px 7px 8px -4px, rgba(0, 150, 0, 0.25) 0px 12px 17px 2px,
+    box-shadow:
+      rgba(0, 150, 0, 0.25) 0px 7px 8px -4px,
+      rgba(0, 150, 0, 0.25) 0px 12px 17px 2px,
       rgba(0, 150, 0, 0.25) 0px 5px 22px 4px;
   }
   100% {
@@ -660,7 +664,9 @@ a {
 }
 @keyframes purpleFade {
   0% {
-    box-shadow: rgba(115, 0, 75, 0.25) 0px 7px 8px -4px, rgba(115, 0, 75, 0.25) 0px 12px 17px 2px,
+    box-shadow:
+      rgba(115, 0, 75, 0.25) 0px 7px 8px -4px,
+      rgba(115, 0, 75, 0.25) 0px 12px 17px 2px,
       rgba(115, 0, 75, 0.25) 0px 5px 22px 4px;
   }
   100% {

--- a/packages/common-ui/src/components/cardRendering/MarkdownRendererHelpers.ts
+++ b/packages/common-ui/src/components/cardRendering/MarkdownRendererHelpers.ts
@@ -1,4 +1,4 @@
-import { Token, MarkedToken, Tokens } from 'marked';
+import { MarkedToken, Tokens } from 'marked';
 import * as marked from 'marked';
 
 /**
@@ -41,7 +41,7 @@ export function splitTextToken(token: Tokens.Text): Tokens.Text[] {
     const rawChunks = splitByDelimiters(token.raw, '{{', '}}');
 
     if (textChunks.length === rawChunks.length) {
-      return textChunks.map((c, i) => {
+      return textChunks.map((_c, i) => {
         return {
           type: 'text',
           text: textChunks[i],

--- a/packages/common-ui/src/components/studentInputs/BaseUserInput.ts
+++ b/packages/common-ui/src/components/studentInputs/BaseUserInput.ts
@@ -4,7 +4,6 @@ import { useCardPreviewModeStore } from '../../stores/useCardPreviewModeStore';
 import { ViewComponent } from '../../composables/Displayable';
 import { isQuestionView } from '../../composables/CompositionViewable';
 import { QuestionRecord } from '@vue-skuilder/db';
-import { Store } from 'pinia';
 
 export default defineComponent({
   name: 'UserInput',

--- a/packages/common-ui/src/plugins/pinia.ts
+++ b/packages/common-ui/src/plugins/pinia.ts
@@ -15,7 +15,7 @@ export const getPinia = (): Pinia | null => {
 
 // Create a plugin that the main app can use
 export const piniaPlugin: Plugin = {
-  install(app, options) {
+  install(_app, options) {
     const pinia = options?.pinia;
     if (pinia) {
       setPinia(pinia);

--- a/packages/common-ui/tsconfig.json
+++ b/packages/common-ui/tsconfig.json
@@ -1,21 +1,16 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "target": "ES2020",
         "module": "ESNext",
         "moduleResolution": "node",
         "jsx": "preserve",
-        "strict": true,
-        "skipLibCheck": true,
-        "esModuleInterop": true,
         "isolatedModules": true,
         "resolveJsonModule": true,
         "useDefineForClassFields": true,
         "sourceMap": true,
         "baseUrl": ".",
         "lib": ["ESNext", "DOM", "DOM.Iterable"],
-        "paths": {
-            "@/*": ["src/*"]
-        },
         "types": ["vite/client", "vitest/globals", "cypress", "pouchdb"]
     },
     "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"],

--- a/packages/common-ui/vite.config.js
+++ b/packages/common-ui/vite.config.js
@@ -1,7 +1,8 @@
+// packages/common-ui/vite.config.js
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
-import { fileURLToPath, URL } from 'node:url';
 import { resolve } from 'path';
+import { createBaseResolve } from '../../vite.config.base.js';
 
 export default defineConfig({
   build: {
@@ -18,7 +19,14 @@ export default defineConfig({
     },
     rollupOptions: {
       // External packages that shouldn't be bundled
-      external: ['vue', 'vue-router', 'vuetify', 'pinia', '@vue-skuilder/db', '@vue-skuilder/common'],
+      external: [
+        'vue',
+        'vue-router',
+        'vuetify',
+        'pinia',
+        '@vue-skuilder/db',
+        '@vue-skuilder/common',
+      ],
       output: {
         // Global variables to use in UMD build for externalized deps
         globals: {
@@ -29,7 +37,7 @@ export default defineConfig({
           '@vue-skuilder/db': 'VueSkuilderDb',
           '@vue-skuilder/common': 'VueSkuilderCommon',
         },
-        // Preserve CSS in the output bundle
+        // Preserve CSS in the output bundlest
         assetFileNames: (assetInfo) => {
           return `assets/[name][extname]`;
         },
@@ -40,10 +48,7 @@ export default defineConfig({
     cssCodeSplit: true,
   },
   plugins: [vue()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-    extensions: ['.js', '.ts', '.json', '.vue'],
-  },
+  resolve: createBaseResolve(resolve(__dirname, '../..'), {
+    '@cui': resolve(__dirname, 'src'), // Override for self-imports during build
+  }),
 });

--- a/packages/courses/src/default/questions/anki/AnkiCard.vue
+++ b/packages/courses/src/default/questions/anki/AnkiCard.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import Viewable from '@/base-course/Viewable';
+import Viewable from '@courses/base-course/Viewable';
 
 interface AnkiField {
   font: string;

--- a/packages/courses/src/default/questions/fillIn/fillIn.vue
+++ b/packages/courses/src/default/questions/fillIn/fillIn.vue
@@ -33,7 +33,7 @@ export default defineComponent({
 
   components: {
     // Previously:
-    // MarkdownRenderer: defineAsyncComponent(() => import('@/base-course/Components/MarkdownRenderer.vue')),
+    // MarkdownRenderer: defineAsyncComponent(() => import('@courses/base-course/Components/MarkdownRenderer.vue')),
     //
     // Another option:
     MarkdownRenderer: defineAsyncComponent(() =>

--- a/packages/courses/src/default/questions/fillIn/index.ts
+++ b/packages/courses/src/default/questions/fillIn/index.ts
@@ -1,7 +1,7 @@
 import { Question, splitByDelimiters, containsComponent } from '@vue-skuilder/common-ui';
 import { Answer, RadioMultipleChoiceAnswer, DataShape } from '@vue-skuilder/common';
 import { Validator, ViewData } from '@vue-skuilder/common';
-import { randomInt } from '@/math/utility';
+import { randomInt } from '@courses/math/utility';
 import { FieldType, DataShapeName, Status } from '@vue-skuilder/common';
 import _ from 'lodash';
 import { Tokens } from 'marked';

--- a/packages/courses/src/french/questions/vocab/identify.vue
+++ b/packages/courses/src/french/questions/vocab/identify.vue
@@ -7,10 +7,10 @@
 <script lang="ts">
 import { defineComponent, computed, PropType } from 'vue';
 import { useViewable, useQuestionView } from '@vue-skuilder/common-ui';
-import { VocabQuestion } from '@/french/questions/vocab';
+import { VocabQuestion } from '@courses/french/questions/vocab';
 import { ViewData } from '@vue-skuilder/common';
-// import AudioAutoPlayer from '@/base-course/Components/AudioAutoPlayer.vue';
-// import UserInputString from '@/base-course/Components/UserInput/UserInputString.vue';
+// import AudioAutoPlayer from '@courses/base-course/Components/AudioAutoPlayer.vue';
+// import UserInputString from '@courses/base-course/Components/UserInput/UserInputString.vue';
 
 export default defineComponent({
   name: 'IdentifyVocab',

--- a/packages/courses/src/sightsing/questions/IdentifyKey/IdentifyKey.vue
+++ b/packages/courses/src/sightsing/questions/IdentifyKey/IdentifyKey.vue
@@ -10,7 +10,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, PropType } from 'vue';
-import MusicScoreRenderer from '@/components/MusicScoreRender.vue';
+import MusicScoreRenderer from '@courses/components/MusicScoreRender.vue';
 import { RadioMultipleChoice, useViewable, useQuestionView } from '@vue-skuilder/common-ui';
 import { ViewData } from '@vue-skuilder/common';
 import { IdentifyKeyQuestion, keys } from './index';

--- a/packages/courses/src/typing/questions/single-letter/keyboardView.vue
+++ b/packages/courses/src/typing/questions/single-letter/keyboardView.vue
@@ -40,7 +40,7 @@
 import { defineComponent, onMounted, onUnmounted, computed, PropType } from 'vue';
 import { useViewable, useQuestionView } from '@vue-skuilder/common-ui';
 import { TypeLetterQuestion } from './index';
-import { ViewData } from '@/base-course/Interfaces/ViewData';
+import { ViewData } from '@vue-skuilder/common';
 
 export default defineComponent({
   name: 'KeyboardQuestionView',
@@ -59,7 +59,7 @@ export default defineComponent({
 
   setup(props, { emit }) {
     const viewableUtils = useViewable(props, emit, 'KeyboardQuestionView');
-    const questionUtils = useQuestionView<TypeLetterQuestion>(viewableUtils, props.modifyDifficulty);
+    const questionUtils = useQuestionView<TypeLetterQuestion>(viewableUtils);
 
     // Initialize question immediately
     questionUtils.question.value = new TypeLetterQuestion(props.data);

--- a/packages/courses/src/word-work/questions/spelling/textBox.vue
+++ b/packages/courses/src/word-work/questions/spelling/textBox.vue
@@ -17,7 +17,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, PropType } from 'vue';
-import { SpellingQuestion } from '@/word-work/questions/spelling';
+import { SpellingQuestion } from '@courses/word-work/questions/spelling';
 import { AudioAutoPlayer, UserInputString, useViewable, useQuestionView } from '@vue-skuilder/common-ui';
 
 import { ViewData } from '@vue-skuilder/common';

--- a/packages/courses/tsconfig.json
+++ b/packages/courses/tsconfig.json
@@ -1,24 +1,18 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "skipLibCheck": true,
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "preserve",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "target": "ES2020",
+        "useDefineForClassFields": true,
+        "module": "ESNext",
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "skipLibCheck": true,
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "preserve"
+    },
+    "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+    "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/courses/vite.config.ts
+++ b/packages/courses/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
+import { createBaseResolve } from '../../vite.config.base.js';
 
 export default defineConfig({
   plugins: [
@@ -14,11 +15,9 @@ export default defineConfig({
       include: ['src/**/*.ts', 'src/**/*.d.ts', 'src/**/*.vue'],
     }),
   ],
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, 'src'),
-    },
-  },
+  resolve: createBaseResolve(resolve(__dirname, '../..'), {
+    '@courses': resolve(__dirname, 'src'), // Override for self-imports during build
+  }),
   // Add assetsInclude to explicitly handle SVG assets
   assetsInclude: ['**/*.svg'],
   build: {

--- a/packages/db/src/core/interfaces/contentSource.ts
+++ b/packages/db/src/core/interfaces/contentSource.ts
@@ -1,7 +1,8 @@
+import { getDataLayer } from '@/factory';
 import { UserDBInterface } from '..';
 import { StudentClassroomDB } from '../../impl/pouch/classroomDB';
-import { CourseDB } from '../../impl/pouch/courseDB';
 import { ScheduledCard } from '@/core/types/user';
+import { logger } from '@/util/logger';
 
 export type StudySessionFailedItem = StudySessionFailedNewItem | StudySessionFailedReviewItem;
 
@@ -57,8 +58,14 @@ export async function getStudySource(
     return await StudentClassroomDB.factory(source.id, user);
   } else {
     // if (source.type === 'course') - removed so tsc is certain something returns
-    return new CourseDB(source.id, async () => {
-      return user;
-    });
+    // return new CourseDB(source.id, async () => {
+    //   return user;
+    // });
+    logger.info(`[cs]getting content source:`);
+    logger.info(`[cs]\t${JSON.stringify(source)}`);
+    logger.info(`[cs]\t${JSON.stringify(user)}`);
+
+    //
+    return getDataLayer().getCourseDB(source as unknown as string) as unknown as StudyContentSource;
   }
 }

--- a/packages/db/src/core/interfaces/contentSource.ts
+++ b/packages/db/src/core/interfaces/contentSource.ts
@@ -1,8 +1,8 @@
-import { getDataLayer } from '@/factory';
+import { getDataLayer } from '@db/factory';
 import { UserDBInterface } from '..';
 import { StudentClassroomDB } from '../../impl/pouch/classroomDB';
-import { ScheduledCard } from '@/core/types/user';
-import { logger } from '@/util/logger';
+import { ScheduledCard } from '@db/core/types/user';
+import { logger } from '@db/util/logger';
 
 export type StudySessionFailedItem = StudySessionFailedNewItem | StudySessionFailedReviewItem;
 

--- a/packages/db/src/core/interfaces/userDB.ts
+++ b/packages/db/src/core/interfaces/userDB.ts
@@ -3,12 +3,12 @@ import {
   CourseRegistration,
   CourseRegistrationDoc,
   ScheduledCard,
-} from '@/core/types/user';
+} from '@db/core/types/user';
 import { CourseElo, Status } from '@vue-skuilder/common';
 import { Moment } from 'moment';
 import { CardHistory, CardRecord } from '../types/types-legacy';
 import { UserConfig } from '../types/user';
-import { DocumentUpdater } from '@/study';
+import { DocumentUpdater } from '@db/study';
 
 /**
  * User data and authentication

--- a/packages/db/src/impl/pouch/adminDB.ts
+++ b/packages/db/src/impl/pouch/adminDB.ts
@@ -1,5 +1,5 @@
 import pouch from './pouchdb-setup';
-import { ENV } from '@/factory';
+import { ENV } from '@db/factory';
 import {
   pouchDBincludeCredentialsConfig,
   getStartAndEndKeys,
@@ -9,9 +9,9 @@ import {
 import { TeacherClassroomDB, ClassroomLookupDB } from './classroomDB';
 import { PouchError } from './types';
 
-import { AdminDBInterface } from '@/core';
+import { AdminDBInterface } from '@db/core';
 import CourseLookup from './courseLookupDB';
-import { logger } from '@/util/logger';
+import { logger } from '@db/util/logger';
 
 export class AdminDB implements AdminDBInterface {
   private usersDB!: PouchDB.Database;

--- a/packages/db/src/impl/pouch/auth.ts
+++ b/packages/db/src/impl/pouch/auth.ts
@@ -1,6 +1,6 @@
-import { ENV } from '@/factory';
+import { ENV } from '@db/factory';
 import { GuestUsername } from '../../core/types/types-legacy';
-import { logger } from '@/util/logger';
+import { logger } from '@db/util/logger';
 
 interface SessionResponse {
   info: unknown;

--- a/packages/db/src/impl/pouch/classroomDB.ts
+++ b/packages/db/src/impl/pouch/classroomDB.ts
@@ -2,10 +2,10 @@ import {
   StudyContentSource,
   StudySessionNewItem,
   StudySessionReviewItem,
-} from '@/core/interfaces/contentSource';
+} from '@db/core/interfaces/contentSource';
 import { ClassroomConfig } from '@vue-skuilder/common';
-import { ENV } from '@/factory';
-import { logger } from '@/util/logger';
+import { ENV } from '@db/factory';
+import { logger } from '@db/util/logger';
 import moment from 'moment';
 import pouch from './pouchdb-setup';
 import {
@@ -16,15 +16,15 @@ import {
 } from '.';
 import { CourseDB, getTag } from './courseDB';
 
-import { UserDBInterface } from '@/core';
+import { UserDBInterface } from '@db/core';
 import {
   AssignedContent,
   AssignedCourse,
   AssignedTag,
   StudentClassroomDBInterface,
   TeacherClassroomDBInterface,
-} from '@/core/interfaces/classroomDB';
-import { ScheduledCard } from '@/core/types/user';
+} from '@db/core/interfaces/classroomDB';
+import { ScheduledCard } from '@db/core/types/user';
 
 const classroomLookupDBTitle = 'classdb-lookup';
 export const CLASSROOM_CONFIG = 'ClassroomConfig';

--- a/packages/db/src/impl/pouch/courseAPI.ts
+++ b/packages/db/src/impl/pouch/courseAPI.ts
@@ -1,6 +1,6 @@
 import pouch from './pouchdb-setup';
 import { pouchDBincludeCredentialsConfig } from '.';
-import { ENV } from '@/factory';
+import { ENV } from '@db/factory';
 // import { DataShape } from '../..base-course/Interfaces/DataShape';
 import { NameSpacer, ShapeDescriptor } from '@vue-skuilder/common';
 import { CourseConfig, DataShape } from '@vue-skuilder/common';
@@ -9,7 +9,7 @@ import { CourseDB, createTag, updateCardElo } from './courseDB';
 import { CardData, DisplayableData, DocType, Tag } from '../../core/types/types-legacy';
 import { prepareNote55 } from '@vue-skuilder/common';
 import { User } from './userDB';
-import { logger } from '@/util/logger';
+import { logger } from '@db/util/logger';
 
 /**
  *

--- a/packages/db/src/impl/pouch/courseDB.ts
+++ b/packages/db/src/impl/pouch/courseDB.ts
@@ -1,5 +1,5 @@
-import { CourseDBInterface, CourseInfo, CoursesDBInterface, UserDBInterface } from '@/core';
-import { ScheduledCard } from '@/core/types/user';
+import { CourseDBInterface, CourseInfo, CoursesDBInterface, UserDBInterface } from '@db/core';
+import { ScheduledCard } from '@db/core/types/user';
 import {
   CourseConfig,
   CourseElo,
@@ -21,11 +21,11 @@ import { CardData, DocType, SkuilderCourseData, Tag, TagStub } from '../../core/
 import { logger } from '../../util/logger';
 import { GET_CACHED } from './clientCache';
 import { addNote55, addTagToCard, getCredentialledCourseConfig, getTagID } from './courseAPI';
-import { DataLayerResult } from '@/core/types/db';
+import { DataLayerResult } from '@db/core/types/db';
 import { PouchError } from './types';
 import CourseLookup from './courseLookupDB';
-import { ContentNavigationStrategyData } from '@/core/types/contentNavigationStrategy';
-import { ContentNavigator, Navigators } from '@/core/navigators';
+import { ContentNavigationStrategyData } from '@db/core/types/contentNavigationStrategy';
+import { ContentNavigator, Navigators } from '@db/core/navigators';
 
 export class CoursesDB implements CoursesDBInterface {
   _courseIDs: string[] | undefined;

--- a/packages/db/src/impl/pouch/courseLookupDB.ts
+++ b/packages/db/src/impl/pouch/courseLookupDB.ts
@@ -1,5 +1,5 @@
 import pouch from './pouchdb-setup';
-import { ENV } from '@/factory';
+import { ENV } from '@db/factory';
 import { logger } from '../../util/logger';
 
 const courseLookupDBTitle = 'coursedb-lookup';

--- a/packages/db/src/impl/pouch/index.ts
+++ b/packages/db/src/impl/pouch/index.ts
@@ -1,12 +1,12 @@
-import { ENV } from '@/factory';
+import { ENV } from '@db/factory';
 import { DocType, GuestUsername, log, SkuilderCourseData } from '../../core/types/types-legacy';
 // import { getCurrentUser } from '../../stores/useAuthStore';
 import moment, { Moment } from 'moment';
-import { logger } from '@/util/logger';
+import { logger } from '@db/util/logger';
 
 import pouch from './pouchdb-setup';
 
-import { ScheduledCard } from '@/core/types/user';
+import { ScheduledCard } from '@db/core/types/user';
 import process from 'process';
 import { getUserDB } from './userDB';
 

--- a/packages/db/src/impl/pouch/user-course-relDB.ts
+++ b/packages/db/src/impl/pouch/user-course-relDB.ts
@@ -1,4 +1,9 @@
-import { ScheduledCard, UserCourseSetting, UserCourseSettings, UsrCrsDataInterface } from '@/core';
+import {
+  ScheduledCard,
+  UserCourseSetting,
+  UserCourseSettings,
+  UsrCrsDataInterface,
+} from '@db/core';
 import moment, { Moment } from 'moment';
 import { getStartAndEndKeys, REVIEW_PREFIX, REVIEW_TIME_FORMAT } from '.';
 import { CourseDB } from './courseDB';

--- a/packages/db/src/impl/pouch/userDB.ts
+++ b/packages/db/src/impl/pouch/userDB.ts
@@ -1,6 +1,6 @@
-import { getCardHistoryID } from '@/core/util';
+import { getCardHistoryID } from '@db/core/util';
 import { CourseElo, Status } from '@vue-skuilder/common';
-import { ENV } from '@/factory';
+import { ENV } from '@db/factory';
 import moment, { Moment } from 'moment';
 import { GuestUsername } from '../../core/types/types-legacy';
 import pouch from './pouchdb-setup';
@@ -12,15 +12,15 @@ import {
   UserCourseSetting,
   UserDBInterface,
   UsrCrsDataInterface,
-} from '@/core';
+} from '@db/core';
 import {
   ActivityRecord,
   CourseRegistration,
   CourseRegistrationDoc,
   ScheduledCard,
   UserConfig,
-} from '@/core/types/user';
-import { DocumentUpdater } from '@/study';
+} from '@db/core/types/user';
+import { DocumentUpdater } from '@db/study';
 import { CardHistory, CardRecord } from '../../core/types/types-legacy';
 import {
   filterAllDocsByPrefix,

--- a/packages/db/src/impl/static/StaticDataLayerProvider.ts
+++ b/packages/db/src/impl/static/StaticDataLayerProvider.ts
@@ -28,7 +28,7 @@ export class StaticDataLayerProvider implements DataLayerProvider {
 
   constructor(config: Partial<StaticDataLayerConfig>) {
     this.config = {
-      staticContentPath: config.staticContentPath || '/static-content',
+      staticContentPath: config.staticContentPath || '/static-courses',
       localStoragePrefix: config.localStoragePrefix || 'skuilder-static',
       manifests: config.manifests || {},
     };
@@ -84,5 +84,3 @@ export class StaticDataLayerProvider implements DataLayerProvider {
     throw new Error('Admin functions not supported in static mode');
   }
 }
-
-

--- a/packages/db/src/impl/static/StaticDataUnpacker.ts
+++ b/packages/db/src/impl/static/StaticDataUnpacker.ts
@@ -4,7 +4,7 @@ import { StaticCourseManifest, ChunkMetadata } from '../../util/packer/types';
 import { logger } from '../../util/logger';
 import * as fs from 'fs';
 import * as path from 'path';
-import { DocType } from '@/core';
+import { DocType } from '@db/core';
 
 interface EloIndexEntry {
   elo: number;
@@ -130,7 +130,7 @@ export class StaticDataUnpacker {
   private findChunkForDocument(docId: string): ChunkMetadata | undefined {
     // Determine document type from ID pattern by checking all DocType enum members
     let expectedDocType: DocType | undefined = undefined;
-    
+
     // Check for ID prefixes matching any DocType enum value
     for (const docType of Object.values(DocType)) {
       if (docId.startsWith(`${docType}-`)) {

--- a/packages/db/src/impl/static/coursesDB.ts
+++ b/packages/db/src/impl/static/coursesDB.ts
@@ -10,7 +10,9 @@ export class StaticCoursesDB implements CoursesDBInterface {
 
   async getCourseConfig(courseId: string): Promise<CourseConfig> {
     if (!this.manifests[courseId]) {
-      throw new Error(`Course ${courseId} not found`);
+      // throw new Error(`Course ${courseId} not found`);
+      logger.warn(`Course ${courseId} not found`);
+      return {} as CourseConfig; // Return empty config if course not found
     }
 
     // Would need to fetch the course config from static files

--- a/packages/db/src/study/SessionController.ts
+++ b/packages/db/src/study/SessionController.ts
@@ -5,11 +5,11 @@ import {
   StudySessionItem,
   StudySessionNewItem,
   StudySessionReviewItem,
-} from '@/impl/pouch';
+} from '@db/impl/pouch';
 
-import { CardRecord } from '@/core';
-import { Loggable } from '@/util';
-import { ScheduledCard } from '@/core/types/user';
+import { CardRecord } from '@db/core';
+import { Loggable } from '@db/util';
+import { ScheduledCard } from '@db/core/types/user';
 
 function randomInt(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;

--- a/packages/db/src/study/SpacedRepetition.ts
+++ b/packages/db/src/study/SpacedRepetition.ts
@@ -1,6 +1,6 @@
-import { CardHistory, CardRecord, QuestionRecord } from '@/core/types/types-legacy';
-import { areQuestionRecords } from '@/core/util';
-import { Update } from '@/impl/pouch/updateQueue';
+import { CardHistory, CardRecord, QuestionRecord } from '@db/core/types/types-legacy';
+import { areQuestionRecords } from '@db/core/util';
+import { Update } from '@db/impl/pouch/updateQueue';
 import moment from 'moment';
 import { logger } from '../util/logger';
 

--- a/packages/db/src/study/getCardDataShape.ts
+++ b/packages/db/src/study/getCardDataShape.ts
@@ -1,7 +1,7 @@
 import { allCourses } from '@vue-skuilder/courses';
 import { log, NameSpacer, CourseConfig, DataShape } from '@vue-skuilder/common';
-import { CardData, DisplayableData } from '@/core';
-import { getCourseDB } from '@/impl/pouch/courseAPI';
+import { CardData, DisplayableData } from '@db/core';
+import { getCourseDB } from '@db/impl/pouch/courseAPI';
 
 export async function getCardDataShape(courseID: string, cardID: string) {
   const dataShapes: DataShape[] = [];

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  },
-  "include": ["src"]
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "noEmit": true
+    },
+    "include": ["src"]
 }

--- a/packages/e2e-db/tsconfig.json
+++ b/packages/e2e-db/tsconfig.json
@@ -4,9 +4,6 @@
         "module": "CommonJS",
         "moduleResolution": "Node",
         "noEmit": true,
-        "paths": {
-            "@/*": ["./src/*"]
-        },
         "types": ["jest", "node"]
     },
     "include": ["src/**/*"],

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -13,7 +13,6 @@
     // Module resolution
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
       "*": ["node_modules/*"]
     },
     "typeRoots": ["./node_modules/@types", "./types"],

--- a/packages/platform-ui/src/components/Courses/CourseCardBrowser.vue
+++ b/packages/platform-ui/src/components/Courses/CourseCardBrowser.vue
@@ -116,7 +116,7 @@
 
 <script lang="ts">
 import { displayableDataToViewData } from '@vue-skuilder/common';
-import TagsInput from '@/components/Edit/TagsInput.vue';
+import TagsInput from '@pui/components/Edit/TagsInput.vue';
 import { PaginatingToolbar, ViewComponent, CardLoader, alertUser } from '@vue-skuilder/common-ui';
 import { allCourses } from '@vue-skuilder/courses';
 import { getDataLayer, CourseDBInterface, CardData, DisplayableData, Tag } from '@vue-skuilder/db';
@@ -354,7 +354,9 @@ export default defineComponent({
   max-height: auto;
   transform: scale(1, 1);
   transform-origin: top;
-  transition: transform 0.3s ease, max-height 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    max-height 0.3s ease;
 }
 .component-scale-enter,
 .component-fade-leave-to {

--- a/packages/platform-ui/src/components/Edit/CourseEditor.vue
+++ b/packages/platform-ui/src/components/Edit/CourseEditor.vue
@@ -44,13 +44,12 @@
             <component-registration :course="course" class="mt-4" />
           </v-container>
         </v-window-item>
-        
+
         <v-window-item value="navigation">
           <v-container fluid>
-            <navigation-strategy-editor :course-id="course" />    
+            <navigation-strategy-editor :course-id="course" />
           </v-container>
         </v-window-item>
-        
       </v-window>
     </div>
   </div>
@@ -58,15 +57,15 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import ComponentRegistration from '@/components/Edit/ComponentRegistration/ComponentRegistration.vue';
-import NavigationStrategyEditor from '@/components/Edit/NavigationStrategy/NavigationStrategyEditor.vue';
+import ComponentRegistration from '@pui/components/Edit/ComponentRegistration/ComponentRegistration.vue';
+import NavigationStrategyEditor from '@pui/components/Edit/NavigationStrategy/NavigationStrategyEditor.vue';
 import { allCourses } from '@vue-skuilder/courses';
 import { BlanksCard, BlanksCardDataShapes } from '@vue-skuilder/courses';
 import { CourseConfig, NameSpacer, DataShape } from '@vue-skuilder/common';
 import DataInputForm from './ViewableDataInputForm/DataInputForm.vue';
 import BulkImportView from './BulkImportView.vue'; // Added import
 import { getDataLayer } from '@vue-skuilder/db';
-import { useDataInputFormStore } from '@/stores/useDataInputFormStore';
+import { useDataInputFormStore } from '@pui/stores/useDataInputFormStore';
 
 export default defineComponent({
   name: 'CourseEditor',

--- a/packages/platform-ui/src/components/Edit/ViewableDataInputForm/DataInputForm.vue
+++ b/packages/platform-ui/src/components/Edit/ViewableDataInputForm/DataInputForm.vue
@@ -82,9 +82,9 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { DataShape } from '@vue-skuilder/common';
-import CardBrowser from '@/components/Edit/CardBrowser.vue';
-import TagsInput, { TagsInputInstance } from '@/components/Edit/TagsInput.vue';
-import { FieldInputInstance, isFieldInput } from '@/components/Edit/ViewableDataInputForm/FieldInput.types';
+import CardBrowser from '@pui/components/Edit/CardBrowser.vue';
+import TagsInput, { TagsInputInstance } from '@pui/components/Edit/TagsInput.vue';
+import { FieldInputInstance, isFieldInput } from '@pui/components/Edit/ViewableDataInputForm/FieldInput.types';
 import { alertUser } from '@vue-skuilder/common-ui';
 import { allCourses } from '@vue-skuilder/courses';
 import { getDataLayer, CourseDBInterface } from '@vue-skuilder/db';
@@ -98,7 +98,7 @@ import NumberInput from './FieldInputs/NumberInput.vue';
 import StringInput from './FieldInputs/StringInput.vue';
 import ChessPuzzleInput from './FieldInputs/ChessPuzzleInput.vue';
 import { CourseElo } from '@vue-skuilder/common';
-import { useDataInputFormStore } from '@/stores/useDataInputFormStore';
+import { useDataInputFormStore } from '@pui/stores/useDataInputFormStore';
 import { ViewData } from '@vue-skuilder/common';
 import { Question, getCurrentUser } from '@vue-skuilder/common-ui';
 

--- a/packages/platform-ui/src/components/Edit/ViewableDataInputForm/FieldInputs/AudioInput.vue
+++ b/packages/platform-ui/src/components/Edit/ViewableDataInputForm/FieldInputs/AudioInput.vue
@@ -41,7 +41,7 @@ image and audio inputs are semi deprecated - not in use right now -
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import { ValidatingFunction } from '@/base-course/Interfaces/ValidatingFunction';
+import { ValidatingFunction } from '@pui/base-course/Interfaces/ValidatingFunction';
 import WaveSurfer from 'wavesurfer.js';
 import FieldInput from '../OptionsFieldInput';
 import MediaStreamRecorder from 'msr';

--- a/packages/platform-ui/src/components/Edit/ViewableDataInputForm/FieldInputs/ImageInput.vue
+++ b/packages/platform-ui/src/components/Edit/ViewableDataInputForm/FieldInputs/ImageInput.vue
@@ -38,7 +38,7 @@ image and audio inputs are semi deprecated - not in use right now -
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ValidatingFunction } from '@/base-course/Interfaces/ValidatingFunction';
+import { ValidatingFunction } from '@pui/base-course/Interfaces/ValidatingFunction';
 import FieldInput from '../OptionsFieldInput';
 
 // [ ] delete this file ? (Jan 6, 2025)

--- a/packages/platform-ui/src/components/Edit/ViewableDataInputForm/FieldInputs/IntegerInput.vue
+++ b/packages/platform-ui/src/components/Edit/ViewableDataInputForm/FieldInputs/IntegerInput.vue
@@ -16,7 +16,7 @@
 import { defineComponent, computed } from 'vue';
 import { integerValidator } from './typeValidators';
 import FieldInput from '../OptionsFieldInput';
-import { ValidatingFunction } from '@/base-course/Interfaces/ValidatingFunction';
+import { ValidatingFunction } from '@pui/base-course/Interfaces/ValidatingFunction';
 
 export default defineComponent({
   name: 'IntegerInput',

--- a/packages/platform-ui/src/components/Edit/ViewableDataInputForm/FieldInputs/NumberInput.vue
+++ b/packages/platform-ui/src/components/Edit/ViewableDataInputForm/FieldInputs/NumberInput.vue
@@ -16,7 +16,7 @@
 import { defineComponent, computed } from 'vue';
 import { numberValidator } from './typeValidators';
 import FieldInput from '../OptionsFieldInput';
-import { ValidatingFunction } from '@/base-course/Interfaces/ValidatingFunction';
+import { ValidatingFunction } from '@pui/base-course/Interfaces/ValidatingFunction';
 
 export default defineComponent({
   name: 'NumberInput',

--- a/packages/platform-ui/src/components/Edit/ViewableDataInputForm/OptionsFieldInput.ts
+++ b/packages/platform-ui/src/components/Edit/ViewableDataInputForm/OptionsFieldInput.ts
@@ -17,7 +17,7 @@ import {
   Status,
   CourseElo,
 } from '@vue-skuilder/common';
-import { useFieldInputStore } from '@/stores/useFieldInputStore';
+import { useFieldInputStore } from '@pui/stores/useFieldInputStore';
 
 export interface FieldInputSetupReturn {
   inputField: Ref<HTMLInputElement | null>;

--- a/packages/platform-ui/src/server/index.ts
+++ b/packages/platform-ui/src/server/index.ts
@@ -1,5 +1,5 @@
 import { Status } from '@vue-skuilder/common';
-import ENV from '@pui/ENVIRONMENT_VARS';
+import ENV from '../ENVIRONMENT_VARS';
 import { ServerRequest } from '@vue-skuilder/common';
 
 const SERVER = ENV.EXPRESS_SERVER_PROTOCOL + '://' + ENV.EXPRESS_SERVER_URL;

--- a/packages/platform-ui/src/server/index.ts
+++ b/packages/platform-ui/src/server/index.ts
@@ -1,5 +1,5 @@
 import { Status } from '@vue-skuilder/common';
-import ENV from '@/ENVIRONMENT_VARS';
+import ENV from '@pui/ENVIRONMENT_VARS';
 import { ServerRequest } from '@vue-skuilder/common';
 
 const SERVER = ENV.EXPRESS_SERVER_PROTOCOL + '://' + ENV.EXPRESS_SERVER_URL;

--- a/packages/platform-ui/src/store.mock.ts
+++ b/packages/platform-ui/src/store.mock.ts
@@ -1,10 +1,10 @@
 // // src/mock/store.ts
 
 // import Vue from 'vue';
-// import { DataShape } from '@/base-course/Interfaces/DataShape';
-// import { ViewData } from '@/base-course/Interfaces/ViewData';
-// import { CourseConfig } from '@/server/types';
-// import { FieldInputInstance } from '@/components/Edit/ViewableDataInputForm/FieldInput.types';
+// import { DataShape } from '@pui/base-course/Interfaces/DataShape';
+// import { ViewData } from '@pui/base-course/Interfaces/ViewData';
+// import { CourseConfig } from '@pui/server/types';
+// import { FieldInputInstance } from '@pui/components/Edit/ViewableDataInputForm/FieldInput.types';
 // import { User } from '@vue-skuilder/db';
 
 // export const GuestUsername: string = 'Guest';

--- a/packages/platform-ui/src/stores/useDataInputFormStore.ts
+++ b/packages/platform-ui/src/stores/useDataInputFormStore.ts
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia';
-import { DataShape } from '@/base-course/Interfaces/DataShape';
-import { CourseConfig } from '@/server/types';
-import { FieldInputInstance } from '@/components/Edit/ViewableDataInputForm/FieldInput.types';
+import { DataShape } from '@pui/base-course/Interfaces/DataShape';
+import { CourseConfig } from '@pui/server/types';
+import { FieldInputInstance } from '@pui/components/Edit/ViewableDataInputForm/FieldInput.types';
 import { useFieldInputStore } from './useFieldInputStore';
-import { ViewComponent } from '@/base-course/Displayable';
+import { ViewComponent } from '@pui/base-course/Displayable';
 
 interface DataInputForm {
   // current props

--- a/packages/platform-ui/src/views/Classrooms.vue
+++ b/packages/platform-ui/src/views/Classrooms.vue
@@ -98,9 +98,9 @@
 import { defineComponent } from 'vue';
 import { Status, ServerRequestType, JoinClassroom, LeaveClassroom, DeleteClassroom } from '@vue-skuilder/common';
 import { getDataLayer, UserDBInterface } from '@vue-skuilder/db';
-import serverRequest from '@/server/index';
+import serverRequest from '@pui/server/index';
 import { alertUser } from '@vue-skuilder/common-ui';
-import ClassroomEditor from '@/components/Classrooms/CreateClassroom.vue';
+import ClassroomEditor from '@pui/components/Classrooms/CreateClassroom.vue';
 import { getCurrentUser } from '@vue-skuilder/common-ui';
 
 interface CourseReg {

--- a/packages/platform-ui/src/views/Courses.vue
+++ b/packages/platform-ui/src/views/Courses.vue
@@ -81,8 +81,8 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import CourseEditor from '@/components/Courses/CourseEditor.vue';
-import CourseStubCard from '@/components/Courses/CourseStubCard.vue';
+import CourseEditor from '@pui/components/Courses/CourseEditor.vue';
+import CourseStubCard from '@pui/components/Courses/CourseStubCard.vue';
 import _ from 'lodash';
 import serverRequest from '../server';
 import { ServerRequestType, CourseConfig, Status } from '@vue-skuilder/common';

--- a/packages/platform-ui/src/views/Home.vue
+++ b/packages/platform-ui/src/views/Home.vue
@@ -19,10 +19,10 @@
 </template>
 
 <script lang="ts">
-import TextSwap from '@/components/TextSwap.vue';
+import TextSwap from '@pui/components/TextSwap.vue';
 import { defineComponent } from 'vue';
 import { useDisplay } from 'vuetify';
-import { ITextSwap } from '@/components/TextSwap.vue';
+import { ITextSwap } from '@pui/components/TextSwap.vue';
 
 interface Data {
   swapIntervalID: number | null;

--- a/packages/platform-ui/src/views/Study.vue
+++ b/packages/platform-ui/src/views/Study.vue
@@ -36,12 +36,7 @@
         <v-container class="text-center">
           <v-row justify="center" align="center" style="min-height: 50vh">
             <v-col cols="12">
-              <v-progress-circular
-                size="70"
-                width="7"
-                color="primary"
-                indeterminate
-              ></v-progress-circular>
+              <v-progress-circular size="70" width="7" color="primary" indeterminate></v-progress-circular>
               <div class="text-h5 mt-4">Preparing your study session...</div>
               <div class="text-subtitle-1 mt-2">Getting your learning materials ready</div>
             </v-col>
@@ -56,7 +51,9 @@
             <v-col cols="12">
               <v-icon size="64" color="error">mdi-alert-circle</v-icon>
               <div class="text-h5 mt-4 text-error">Session Preparation Failed</div>
-              <div class="text-subtitle-1 mt-2">{{ errorMessage || 'There was a problem preparing your study session.' }}</div>
+              <div class="text-subtitle-1 mt-2">
+                {{ errorMessage || 'There was a problem preparing your study session.' }}
+              </div>
               <v-btn color="primary" class="mt-6" @click="refreshRoute">Try Again</v-btn>
             </v-col>
           </v-row>
@@ -80,9 +77,9 @@
 </template>
 
 <script lang="ts">
-import SessionConfiguration from '@/components/Study/SessionConfiguration.vue';
+import SessionConfiguration from '@pui/components/Study/SessionConfiguration.vue';
 import { getCurrentUser, useConfigStore } from '@vue-skuilder/common-ui';
-import { useDataInputFormStore } from '@/stores/useDataInputFormStore';
+import { useDataInputFormStore } from '@pui/stores/useDataInputFormStore';
 import { CourseConfig } from '@vue-skuilder/common';
 import { StudySession, type StudySessionConfig } from '@vue-skuilder/common-ui';
 import { allCourses } from '@vue-skuilder/courses';
@@ -216,7 +213,7 @@ export default defineComponent({
       this.sessionTimeLimit = timeLimit;
       this.inSession = true;
       this.sessionPrepared = false;
-      
+
       // Adding a console log to debug event handling
       console.log('[Study] Waiting for session-prepared event from StudySession component');
     },

--- a/packages/platform-ui/tsconfig.json
+++ b/packages/platform-ui/tsconfig.json
@@ -1,33 +1,18 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "strictPropertyInitialization": false,
-        "skipLibCheck": true,
         "target": "esnext",
         "module": "esnext",
-        "strict": true,
         "jsx": "preserve",
         "moduleResolution": "node",
         "importHelpers": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        "allowSyntheticDefaultImports": true,
         "allowJs": true,
-        "esModuleInterop": true,
-        "sourceMap": true,
         "composite": true,
         "baseUrl": ".",
         "types": ["node", "jest", "@types/jest", "vuetify", "vite/client"],
-        "paths": {
-            "@/*": ["src/*"],
-            "@vue-skuilder/common-ui": ["../common-ui/src"],
-            "@vue-skuilder/common-ui/*": ["../common-ui/src/*"],
-            "@vue-skuilder/db": ["../db/src"],
-            "@vue-skuilder/db/*": ["../db/src/*"],
-            "@vue-skuilder/common": ["../common/src"],
-            "@vue-skuilder/common/*": ["../common/src/*"],
-            "@vue-skuilder/courses": ["../courses/src"],
-            "@vue-skuilder/courses/*": ["../courses/src/*"]
-        },
         "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
     },
     "include": [

--- a/packages/platform-ui/vite.config.js
+++ b/packages/platform-ui/vite.config.js
@@ -1,10 +1,11 @@
+// packages/platform-ui/vite.config.js
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { VitePWA } from 'vite-plugin-pwa';
 import eslint from 'vite-plugin-eslint';
-import { fileURLToPath, URL } from 'node:url';
 import injectEnvPlugin from './vite-env-plugin';
 import { resolve } from 'path';
+import { createBaseResolve } from '../../vite.config.base.js';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -50,19 +51,13 @@ export default defineConfig({
       exclude: ['node_modules'], // Files to exclude
     }),
   ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-      // events: 'events-browserify',
-      events: 'events',
-      // 'pouchdb': 'pouchdb/lib/index.js',
-      // 'pouchdb-find': 'pouchdb-find/lib/index.js',
-      '@vue-skuilder/db': resolve(__dirname, '../../packages/db/dist/index.mjs'),
-      '@vue-skuilder/common-ui': resolve(__dirname, '../../packages/common-ui/src/index.ts'),
-    },
-    extensions: ['.js', '.ts', '.json', '.vue'],
-    dedupe: ['vue', 'vuetify', 'vue-router', 'pinia', '@vue-skuilder/db', '@vue-skuilder/common'],
-  },
+  resolve: createBaseResolve(resolve(__dirname, '../..'), {
+    '@pui': resolve(__dirname, 'src'), // Override for self-imports during build
+    // events: 'events-browserify',
+    events: 'events',
+    // 'pouchdb': 'pouchdb/lib/index.js',
+    // 'pouchdb-find': 'pouchdb-find/lib/index.js',
+  }),
   optimizeDeps: {
     include: ['events'],
   },

--- a/packages/standalone-ui/src/main.ts
+++ b/packages/standalone-ui/src/main.ts
@@ -23,76 +23,117 @@ import { useAuthStore } from '@vue-skuilder/common-ui';
 import config from '../skuilder.config.json';
 
 (async () => {
-  await initializeDataLayer({
-    type: 'pouch',
-    options: {
-      COUCHDB_SERVER_URL: ENV.COUCHDB_SERVER_URL,
-      COUCHDB_SERVER_PROTOCOL: ENV.COUCHDB_SERVER_PROTOCOL,
-      COURSE_IDS: [ENV.STATIC_COURSE_ID],
-    },
-  });
+  // For static data layer, load manifest
+  let dataLayerOptions: any = {
+    COUCHDB_SERVER_URL: ENV.COUCHDB_SERVER_URL,
+    COUCHDB_SERVER_PROTOCOL: ENV.COUCHDB_SERVER_PROTOCOL,
+    COURSE_IDS: [config.course ? config.course : 'default-course'],
+  };
+
+  if (config.dataLayerType === 'static') {
+    // Load manifest for static mode
+    const courseId = config.course;
+    if (!courseId) {
+      throw new Error('Course ID required for static data layer');
+    }
+
+    try {
+      const manifestResponse = await fetch(`/static-courses/${courseId}/manifest.json`);
+      if (!manifestResponse.ok) {
+        throw new Error(
+          `Failed to load manifest: ${manifestResponse.status} ${manifestResponse.statusText}`
+        );
+      }
+      const manifest = await manifestResponse.json();
+      console.log(`Loaded manifest for course ${courseId}`);
+      console.log(JSON.stringify(manifest));
+
+      dataLayerOptions = {
+        staticContentPath: '/static-courses',
+        manifests: {
+          [courseId]: manifest,
+        },
+      };
+    } catch (error) {
+      console.error('[DEBUG] Failed to load course manifest:', error);
+      throw new Error(`Could not load course manifest for ${courseId}: ${error}`);
+    }
+  }
+
+  try {
+    await initializeDataLayer({
+      type: (config.dataLayerType || 'pouch') as 'pouch' | 'static',
+      options: dataLayerOptions,
+    });
+    console.log('[DEBUG] Data layer initialized successfully');
+  } catch (error) {
+    console.error('[DEBUG] Data layer initialization failed:', error);
+    throw error;
+  }
   const pinia = createPinia();
 
   // Apply theme configuration from skuilder.config.json
-  const themeConfig = config.theme ? {
-    defaultTheme: config.theme.defaultMode || 'light',
-    themes: {
-      light: config.theme.light,
-      dark: config.theme.dark,
-    },
-  } : {
-    defaultTheme: 'light',
-    themes: {
-      light: {
-        dark: false,
-        colors: {
-          primary: '#1976D2',
-          secondary: '#424242',
-          accent: '#82B1FF',
-          error: '#F44336',
-          info: '#2196F3',
-          success: '#4CAF50',
-          warning: '#FF9800',
-          background: '#FFFFFF',
-          surface: '#FFFFFF',
-          'surface-bright': '#FFFFFF',
-          'surface-light': '#EEEEEE',
-          'surface-variant': '#E3F2FD',
-          'on-surface-variant': '#1976D2',
-          'primary-darken-1': '#1565C0',
-          'secondary-darken-1': '#212121',
-          'on-primary': '#FFFFFF',
-          'on-secondary': '#FFFFFF',
-          'on-background': '#212121',
-          'on-surface': '#212121',
+  const themeConfig = config.theme
+    ? {
+        defaultTheme: config.theme.defaultMode || 'light',
+        themes: {
+          light: config.theme.light,
+          dark: config.theme.dark,
         },
-      },
-      dark: {
-        dark: true,
-        colors: {
-          primary: '#2196F3',
-          secondary: '#90A4AE',
-          accent: '#82B1FF',
-          error: '#FF5252',
-          info: '#2196F3',
-          success: '#4CAF50',
-          warning: '#FFC107',
-          background: '#121212',
-          surface: '#1E1E1E',
-          'surface-bright': '#2C2C2C',
-          'surface-light': '#2C2C2C',
-          'surface-variant': '#1A237E',
-          'on-surface-variant': '#82B1FF',
-          'primary-darken-1': '#1976D2',
-          'secondary-darken-1': '#546E7A',
-          'on-primary': '#000000',
-          'on-secondary': '#000000',
-          'on-background': '#FFFFFF',
-          'on-surface': '#FFFFFF',
+      }
+    : {
+        defaultTheme: 'light',
+        themes: {
+          light: {
+            dark: false,
+            colors: {
+              primary: '#1976D2',
+              secondary: '#424242',
+              accent: '#82B1FF',
+              error: '#F44336',
+              info: '#2196F3',
+              success: '#4CAF50',
+              warning: '#FF9800',
+              background: '#FFFFFF',
+              surface: '#FFFFFF',
+              'surface-bright': '#FFFFFF',
+              'surface-light': '#EEEEEE',
+              'surface-variant': '#E3F2FD',
+              'on-surface-variant': '#1976D2',
+              'primary-darken-1': '#1565C0',
+              'secondary-darken-1': '#212121',
+              'on-primary': '#FFFFFF',
+              'on-secondary': '#FFFFFF',
+              'on-background': '#212121',
+              'on-surface': '#212121',
+            },
+          },
+          dark: {
+            dark: true,
+            colors: {
+              primary: '#2196F3',
+              secondary: '#90A4AE',
+              accent: '#82B1FF',
+              error: '#FF5252',
+              info: '#2196F3',
+              success: '#4CAF50',
+              warning: '#FFC107',
+              background: '#121212',
+              surface: '#1E1E1E',
+              'surface-bright': '#2C2C2C',
+              'surface-light': '#2C2C2C',
+              'surface-variant': '#1A237E',
+              'on-surface-variant': '#82B1FF',
+              'primary-darken-1': '#1976D2',
+              'secondary-darken-1': '#546E7A',
+              'on-primary': '#000000',
+              'on-secondary': '#000000',
+              'on-background': '#FFFFFF',
+              'on-surface': '#FFFFFF',
+            },
+          },
         },
-      },
-    },
-  };
+      };
 
   const vuetify = createVuetify({
     components,

--- a/packages/standalone-ui/src/views/StudyView.vue
+++ b/packages/standalone-ui/src/views/StudyView.vue
@@ -28,13 +28,11 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import { ContentSourceID, getDataLayer, UserDBInterface } from '@vue-skuilder/db';
+import { ContentSourceID, getDataLayer } from '@vue-skuilder/db';
 import { StudySession, type StudySessionConfig } from '@vue-skuilder/common-ui';
 import { allCourses } from '@vue-skuilder/courses';
-import { useRouter } from 'vue-router';
 import ENV from '../ENVIRONMENT_VARS';
 
-const router = useRouter();
 const user = getDataLayer().getUserDB();
 const dataLayer = getDataLayer();
 const sessionPrepared = ref(false);

--- a/packages/standalone-ui/tsconfig.json
+++ b/packages/standalone-ui/tsconfig.json
@@ -1,21 +1,16 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "target": "ESNext",
         "useDefineForClassFields": true,
         "module": "ESNext",
         "moduleResolution": "bundler",
-        "strict": true,
         "jsx": "preserve",
         "resolveJsonModule": true,
         "isolatedModules": true,
-        "esModuleInterop": true,
         "lib": ["ESNext", "DOM"],
-        "skipLibCheck": true,
         "noEmit": true,
         "baseUrl": ".",
-        "paths": {
-            "@/*": ["./src/*"]
-        },
         "types": ["vite/client"]
     },
     "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]

--- a/packages/standalone-ui/vite.config.ts
+++ b/packages/standalone-ui/vite.config.ts
@@ -2,47 +2,21 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
-import { fileURLToPath, URL } from 'node:url'; // Import necessary Node.js modules
+import { createBaseResolve } from '../../vite.config.base.js';
 
 export default defineConfig({
   plugins: [vue()],
-  resolve: {
-    alias: {
-      // Alias for internal src paths
-      '@': fileURLToPath(new URL('./src', import.meta.url)), // Use fileURLToPath and URL for robustness
-
-      // --- Link workspace packages to their SOURCE ---
-      // Adjust relative paths as needed based on your monorepo structure
-      // '@vue-skuilder/common-ui': resolve(__dirname, '../../packages/common-ui/src/index.ts'), // Removed - now uses built package
-
-      // Add events alias if needed (often required by dependencies)
-      events: 'events',
-
-      // You might need to alias vue-router if dedupe isn't enough, though unlikely
-      // 'vue-router': resolve(__dirname, 'node_modules/vue-router'),
-    },
-    extensions: ['.js', '.ts', '.json', '.vue'], // Keep standard extensions
-    dedupe: [
-      // Ensure single instances of core libs and workspace packages
-      'vue',
-      'vuetify',
-      'pinia',
-      'vue-router',
-      '@vue-skuilder/db',
-      '@vue-skuilder/common',
-      '@vue-skuilder/common-ui',
-      '@vue-skuilder/courses',
-    ],
-  },
+  resolve: createBaseResolve(resolve(__dirname, '../..'), {
+    '@sui': resolve(__dirname, 'src'), // Override for self-imports during build
+    // Add events alias if needed (often required by dependencies)
+    events: 'events',
+  }),
   // --- Important for linked source dependencies ---
   optimizeDeps: {
     // Help Vite pre-bundle dependencies from linked packages
-    include: [
-      '@vue-skuilder/common-ui',
-      '@vue-skuilder/db',
-      '@vue-skuilder/common',
-      '@vue-skuilder/courses',
-    ],
+    include: ['@vue-skuilder/common', '@vue-skuilder/courses'],
+    exclude: ['@vue-skuilder/common-ui', '@vue-skuilder/db'],
+    force: true,
   },
   server: {
     port: 6173, // distinct from platform-ui

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,16 +1,29 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "strict": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
-  }
+    "compilerOptions": {
+        "target": "ES2022",
+        "strict": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true,
+        "baseUrl": ".",
+        "paths": {
+            "@db/*": ["./packages/db/src/*"],
+            "@common/*": ["./packages/common/src/*"],
+            "@cui/*": ["./packages/common-ui/src/*"],
+            "@courses/*": ["./packages/courses/src/*"],
+            "@express/*": ["./packages/express/src/*"],
+            "@pui/*": ["./packages/platform-ui/src/*"],
+            "@sui/*": ["./packages/standalone-ui/src/*"],
+            "@e2e-db/*": ["./packages/e2e-db/src/*"],
+            "@cli/*": ["./packages/cli/src/*"],
+            "@client/*": ["./packages/client/src/*"]
+        }
+    }
 }

--- a/vite.config.base.js
+++ b/vite.config.base.js
@@ -1,0 +1,70 @@
+import { resolve } from 'path';
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+/**
+ * Creates shared alias mappings for monorepo packages
+ * @param {string} rootDir - Path to the monorepo root directory
+ * @returns {Object} Alias configuration object
+ */
+export function createBaseAliases(rootDir = process.cwd()) {
+  return {
+    // Package-specific aliases (matching tsconfig.base.json)
+    '@db': isDev
+      ? resolve(rootDir, './packages/db/src')
+      : resolve(rootDir, './packages/db/dist'),
+    '@common': isDev
+      ? resolve(rootDir, './packages/common/src')
+      : resolve(rootDir, './packages/common/dist'),
+    '@cui': isDev
+      ? resolve(rootDir, './packages/common-ui/src')
+      : resolve(rootDir, './packages/common-ui/dist'),
+    '@courses': isDev
+      ? resolve(rootDir, './packages/courses/src')
+      : resolve(rootDir, './packages/courses/dist'),
+    '@express': isDev
+      ? resolve(rootDir, './packages/express/src')
+      : resolve(rootDir, './packages/express/dist'),
+    '@pui': isDev
+      ? resolve(rootDir, './packages/platform-ui/src')
+      : resolve(rootDir, './packages/platform-ui/dist'),
+    '@sui': isDev
+      ? resolve(rootDir, './packages/standalone-ui/src')
+      : resolve(rootDir, './packages/standalone-ui/dist'),
+    '@e2e-db': isDev
+      ? resolve(rootDir, './packages/e2e-db/src')
+      : resolve(rootDir, './packages/e2e-db/dist'),
+    '@cli': isDev
+      ? resolve(rootDir, './packages/cli/src')
+      : resolve(rootDir, './packages/cli/dist'),
+    '@client': isDev
+      ? resolve(rootDir, './packages/client/src')
+      : resolve(rootDir, './packages/client/dist'),
+  };
+}
+
+/**
+ * Creates shared Vite resolve configuration
+ * @param {string} rootDir - Path to the monorepo root directory
+ * @param {Object} localAliases - Package-specific aliases to merge
+ * @returns {Object} Vite resolve configuration
+ */
+export function createBaseResolve(rootDir = process.cwd(), localAliases = {}) {
+  return {
+    alias: {
+      ...createBaseAliases(rootDir),
+      ...localAliases,
+    },
+    extensions: ['.js', '.ts', '.json', '.vue'],
+    dedupe: [
+      'vue',
+      'vuetify',
+      'vue-router',
+      'pinia',
+      '@vue-skuilder/db',
+      '@vue-skuilder/common',
+      '@vue-skuilder/common-ui',
+      '@vue-skuilder/courses',
+    ],
+  };
+}

--- a/vite.config.base.js
+++ b/vite.config.base.js
@@ -2,6 +2,8 @@ import { resolve } from 'path';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
+console.info(`[VITE] shared config loaded in ${isDev ? 'development' : 'production'} mode`);
+
 /**
  * Creates shared alias mappings for monorepo packages
  * @param {string} rootDir - Path to the monorepo root directory


### PR DESCRIPTION
Toward #718. Closes #733.

Integrating static db layer with standalone-ui was hindered by monorepo dev utility brittleness:
- no hot-reload on changes library packages when serving application packages
- (worse) quiet caching of library packages by app packages that even made hard-reloads difficult
- inconsistent settings making it very difficult to think about / debug module duplication at runtime - specifically the `db` package which maintains a singleton db access point (so breaks when duplicated at runtime)

This set of changes modifies existing base tsconfig, and adds base vite config such that:
- `@` path resolves are replaced with `@pkgname` resolves. namespaced to allow:
- app packages at dev time resolve directly to live source code of the library packages. Hot reload all the way through the stack.
- dedupe enforcement is standardized (and even seems to work!)

Maybe more could be done toward vite unification + tooling modernization, but this is a large step up from prior state.


Commits:

- **match path to the one generated by cli tool**
- **return impl agnostic content source...**
- **soften failure on crsconfiglookup**
- **[wip] add static manifest load and datalayer init**
- **add shared path resolutions tsconfig**
- **add shared vite cfg**
- **remove @ path configs...**
- **update imports w/ shared paths config**
- **use shared path resolve configs...**
- **update imports w/ namespaced path**
- **use shared path resolve configs...**
- **linting**
- **use shared configs**
- **add a dev/production info logger**
- **use shared configs**
- **linting**
- **linting**
- **migrate to shared cfg paths**
