### PR TITLE
add couchdb view caching for static data packing

### DIFF
--- a/packages/db/src/util/packer/types.ts
+++ b/packages/db/src/util/packer/types.ts
@@ -26,7 +26,7 @@ export interface ChunkMetadata {
 
 export interface IndexMetadata {
   name: string;
-  type: 'btree' | 'hash' | 'spatial';
+  type: 'btree' | 'hash' | 'spatial' | 'view';
   path: string; // Relative path for file writing
 }
 


### PR DESCRIPTION
Toward #718, #757.

PR adds cached view indexing to the `pack` functionality. StaticDB hooks to this packed data are not in place - created #771.