### PR TITLE
static to live

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { createInitCommand } from './commands/init.js';
 import { createPackCommand } from './commands/pack.js';
+import { createUnpackCommand } from './commands/unpack.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -24,6 +25,7 @@ program
 // Add commands
 program.addCommand(createInitCommand());
 program.addCommand(createPackCommand());
+program.addCommand(createUnpackCommand());
 
 program.on('--help', () => {
   console.log('');
@@ -33,6 +35,8 @@ program.on('--help', () => {
   console.log('  $ skuilder init physics --no-interactive --data-layer=dynamic');
   console.log('  $ skuilder pack sample-course-id');
   console.log('  $ skuilder pack biology-101 --server http://localhost:5984 --username admin');
+  console.log('  $ skuilder unpack ./static-courses/biology-101');
+  console.log('  $ skuilder unpack ./my-course --database test-migration --validate');
 });
 
 program.parse();

--- a/packages/cli/src/commands/unpack.ts
+++ b/packages/cli/src/commands/unpack.ts
@@ -1,0 +1,197 @@
+import { Command } from 'commander';
+import PouchDB from 'pouchdb';
+import path from 'path';
+import chalk from 'chalk';
+import { StaticToCouchDBMigrator, validateStaticCourse } from '@vue-skuilder/db';
+
+export function createUnpackCommand(): Command {
+  return new Command('unpack')
+    .description('Unpack a static course directory into CouchDB')
+    .argument('<coursePath>', 'Path to static course directory')
+    .option('-s, --server <url>', 'CouchDB server URL', 'http://localhost:5984')
+    .option('-u, --username <username>', 'CouchDB username')
+    .option('-p, --password <password>', 'CouchDB password')
+    .option('-d, --database <name>', 'Target database name (auto-generated if not provided)')
+    .option('--chunk-size <size>', 'Documents per batch', '100')
+    .option('--skip-attachments', 'Skip attachment uploads')
+    .option('--validate', 'Run migration validation')
+    .option('--cleanup-on-error', 'Clean up database if migration fails')
+    .action(unpackCourse);
+}
+
+interface UnpackOptions {
+  server: string;
+  username?: string;
+  password?: string;
+  database?: string;
+  chunkSize: string;
+  skipAttachments: boolean;
+  validate: boolean;
+  cleanupOnError: boolean;
+}
+
+async function unpackCourse(coursePath: string, options: UnpackOptions) {
+  try {
+    console.log(chalk.cyan(`🔧 Unpacking static course to CouchDB...`));
+    console.log(chalk.gray(`📁 Source: ${path.resolve(coursePath)}`));
+
+    // Validate static course directory
+    console.log(chalk.cyan('🔍 Validating static course...'));
+    const validation = await validateStaticCourse(coursePath);
+    
+    if (!validation.valid) {
+      console.log(chalk.red('❌ Static course validation failed:'));
+      validation.errors.forEach((error: string) => {
+        console.log(chalk.red(`  • ${error}`));
+      });
+      process.exit(1);
+    }
+
+    if (validation.warnings.length > 0) {
+      console.log(chalk.yellow('⚠️  Validation warnings:'));
+      validation.warnings.forEach((warning: string) => {
+        console.log(chalk.yellow(`  • ${warning}`));
+      });
+    }
+
+    console.log(chalk.green('✅ Static course validation passed'));
+    console.log(chalk.gray(`📋 Course: ${validation.courseName || 'Unknown'} (${validation.courseId || 'Unknown ID'})`));
+
+    // Generate database name if not provided
+    let targetDbName = options.database;
+    if (!targetDbName) {
+      const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+      const random = Math.random().toString(36).substring(2, 8);
+      targetDbName = `coursedb-${validation.courseId || 'unknown'}-unpack-${timestamp}-${random}`;
+    }
+
+    // Construct database URL
+    const dbUrl = `${options.server}/${targetDbName}`;
+    console.log(chalk.gray(`📡 Target: ${dbUrl}`));
+
+    // Setup database connection options
+    const dbOptions: Record<string, unknown> = {};
+    if (options.username && options.password) {
+      dbOptions.auth = {
+        username: options.username,
+        password: options.password,
+      };
+    }
+
+    // Create and connect to target database
+    console.log(chalk.cyan('🔄 Creating target database...'));
+    const targetDB = new PouchDB(dbUrl, dbOptions);
+
+    // Test connection by trying to get database info
+    try {
+      await targetDB.info();
+      console.log(chalk.green('✅ Connected to target database'));
+    } catch (error: unknown) {
+      let errorMessage = 'Unknown error';
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      } else if (typeof error === 'string') {
+        errorMessage = error;
+      } else if (error && typeof error === 'object' && 'message' in error) {
+        errorMessage = String((error as { message: unknown }).message);
+      }
+      throw new Error(`Failed to connect to target database: ${errorMessage}`);
+    }
+
+    // Configure migrator
+    const migratorOptions = {
+      chunkBatchSize: parseInt(options.chunkSize),
+      skipAttachments: options.skipAttachments,
+      validateRoundTrip: options.validate,
+      cleanupOnFailure: options.cleanupOnError,
+    };
+
+    console.log(chalk.gray(`📦 Batch size: ${migratorOptions.chunkBatchSize} documents`));
+    console.log(chalk.gray(`📎 Include attachments: ${!migratorOptions.skipAttachments}`));
+    console.log(chalk.gray(`🔍 Validation enabled: ${migratorOptions.validateRoundTrip}`));
+
+    // Setup progress reporting
+    const migrator = new StaticToCouchDBMigrator(migratorOptions);
+    migrator.setProgressCallback((progress: any) => {
+      const percentage = progress.total > 0 ? Math.round((progress.current / progress.total) * 100) : 0;
+      console.log(chalk.cyan(`🔄 ${progress.phase}: ${progress.message} (${progress.current}/${progress.total} - ${percentage}%)`));
+    });
+
+    // Perform migration
+    console.log(chalk.cyan('🚀 Starting migration...'));
+    
+    const result = await migrator.migrateCourse(coursePath, targetDB);
+    
+    if (!result.success) {
+      console.log(chalk.red('\n❌ Migration failed:'));
+      result.errors.forEach((error: string) => {
+        console.log(chalk.red(`  • ${error}`));
+      });
+      
+      if (result.warnings.length > 0) {
+        console.log(chalk.yellow('\n⚠️  Warnings:'));
+        result.warnings.forEach((warning: string) => {
+          console.log(chalk.yellow(`  • ${warning}`));
+        });
+      }
+      
+      process.exit(1);
+    }
+
+    // Success! Display results
+    console.log(chalk.green('\n✅ Successfully unpacked course!'));
+    console.log('');
+    console.log(chalk.white(`📊 Course: ${validation.courseName || 'Unknown'}`));
+    console.log(chalk.white(`📄 Documents: ${result.documentsRestored}`));
+    console.log(chalk.white(`🗃️  Design Docs: ${result.designDocsRestored}`));
+    console.log(chalk.white(`📎 Attachments: ${result.attachmentsRestored}`));
+    console.log(chalk.white(`⏱️  Migration Time: ${(result.migrationTime / 1000).toFixed(1)}s`));
+    console.log(chalk.white(`📡 Database: ${targetDbName}`));
+
+    if (result.warnings.length > 0) {
+      console.log(chalk.yellow('\n⚠️  Migration warnings:'));
+      result.warnings.forEach((warning: string) => {
+        console.log(chalk.yellow(`  • ${warning}`));
+      });
+    }
+
+    // Display next steps
+    console.log('');
+    console.log(chalk.cyan('📝 Next steps:'));
+    console.log(chalk.gray('  • Test the migrated course data in your application'));
+    console.log(chalk.gray('  • Verify document counts and content manually if needed'));
+    console.log(chalk.gray(`  • Use database: ${targetDbName}`));
+    
+    if (!options.validate) {
+      console.log(chalk.gray('  • Consider running with --validate flag for comprehensive verification'));
+    }
+
+  } catch (error: unknown) {
+    console.error(chalk.red('\n❌ Unpacking failed:'));
+    let errorMessage = 'Unknown error';
+    if (error instanceof Error) {
+      errorMessage = error.message;
+      
+      // Show stack trace in development/debug mode
+      if (process.env.DEBUG || process.env.NODE_ENV === 'development') {
+        console.error(chalk.gray('\nStack trace:'));
+        console.error(chalk.gray(error.stack || 'No stack trace available'));
+      }
+    } else if (typeof error === 'string') {
+      errorMessage = error;
+    } else if (error && typeof error === 'object' && 'message' in error) {
+      errorMessage = String((error as { message: unknown }).message);
+    }
+    
+    console.error(chalk.red(errorMessage));
+    console.error('');
+    console.error(chalk.yellow('💡 Troubleshooting tips:'));
+    console.error(chalk.gray('  • Verify the static course directory path is correct'));
+    console.error(chalk.gray('  • Ensure CouchDB is running and accessible'));
+    console.error(chalk.gray('  • Check that manifest.json and chunks/ directory exist'));
+    console.error(chalk.gray('  • Verify database permissions if using authentication'));
+    console.error(chalk.gray('  • Use --validate flag for detailed error information'));
+    
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/unpack.ts
+++ b/packages/cli/src/commands/unpack.ts
@@ -76,7 +76,7 @@ async function unpackCourse(coursePath: string, options: UnpackOptions) {
     if (!targetDbName) {
       const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');
       const random = Math.random().toString(36).substring(2, 8);
-      studioCourseId = `unpack-${validation.courseId || 'unknown'}-${timestamp}-${random}`;
+      studioCourseId = `unpacked_${validation.courseId || 'unknown'}_${timestamp}_${random}`;
       targetDbName = `coursedb-${studioCourseId}`;
     } else {
       // If user provided custom database name, extract studio course ID from it

--- a/packages/cli/src/commands/unpack.ts
+++ b/packages/cli/src/commands/unpack.ts
@@ -14,7 +14,6 @@ export function createUnpackCommand(): Command {
     .option('-p, --password <password>', 'CouchDB password')
     .option('-d, --database <name>', 'Target database name (auto-generated if not provided)')
     .option('--chunk-size <size>', 'Documents per batch', '100')
-    .option('--skip-attachments', 'Skip attachment uploads')
     .option('--validate', 'Run migration validation')
     .option('--cleanup-on-error', 'Clean up database if migration fails')
     .action(unpackCourse);
@@ -26,7 +25,6 @@ interface UnpackOptions {
   password?: string;
   database?: string;
   chunkSize: string;
-  skipAttachments: boolean;
   validate: boolean;
   cleanupOnError: boolean;
 }
@@ -105,13 +103,11 @@ async function unpackCourse(coursePath: string, options: UnpackOptions) {
     // Configure migrator
     const migratorOptions = {
       chunkBatchSize: parseInt(options.chunkSize),
-      skipAttachments: options.skipAttachments,
       validateRoundTrip: options.validate,
       cleanupOnFailure: options.cleanupOnError,
     };
 
     console.log(chalk.gray(`📦 Batch size: ${migratorOptions.chunkBatchSize} documents`));
-    console.log(chalk.gray(`📎 Include attachments: ${!migratorOptions.skipAttachments}`));
     console.log(chalk.gray(`🔍 Validation enabled: ${migratorOptions.validateRoundTrip}`));
 
     // Setup progress reporting

--- a/packages/cli/src/commands/unpack.ts
+++ b/packages/cli/src/commands/unpack.ts
@@ -3,6 +3,7 @@ import PouchDB from 'pouchdb';
 import path from 'path';
 import chalk from 'chalk';
 import { StaticToCouchDBMigrator, validateStaticCourse } from '@vue-skuilder/db';
+import { NodeFileSystemAdapter } from '../utils/NodeFileSystemAdapter.js';
 
 export function createUnpackCommand(): Command {
   return new Command('unpack')
@@ -35,9 +36,12 @@ async function unpackCourse(coursePath: string, options: UnpackOptions) {
     console.log(chalk.cyan(`🔧 Unpacking static course to CouchDB...`));
     console.log(chalk.gray(`📁 Source: ${path.resolve(coursePath)}`));
 
+    // Create file system adapter
+    const fileSystemAdapter = new NodeFileSystemAdapter();
+
     // Validate static course directory
     console.log(chalk.cyan('🔍 Validating static course...'));
-    const validation = await validateStaticCourse(coursePath);
+    const validation = await validateStaticCourse(coursePath, fileSystemAdapter);
     
     if (!validation.valid) {
       console.log(chalk.red('❌ Static course validation failed:'));
@@ -111,7 +115,7 @@ async function unpackCourse(coursePath: string, options: UnpackOptions) {
     console.log(chalk.gray(`🔍 Validation enabled: ${migratorOptions.validateRoundTrip}`));
 
     // Setup progress reporting
-    const migrator = new StaticToCouchDBMigrator(migratorOptions);
+    const migrator = new StaticToCouchDBMigrator(migratorOptions, fileSystemAdapter);
     migrator.setProgressCallback((progress: any) => {
       const percentage = progress.total > 0 ? Math.round((progress.current / progress.total) * 100) : 0;
       console.log(chalk.cyan(`🔄 ${progress.phase}: ${progress.message} (${progress.current}/${progress.total} - ${percentage}%)`));

--- a/packages/cli/src/utils/NodeFileSystemAdapter.ts
+++ b/packages/cli/src/utils/NodeFileSystemAdapter.ts
@@ -1,0 +1,72 @@
+// packages/cli/src/utils/NodeFileSystemAdapter.ts
+
+import fs from 'fs';
+import path from 'path';
+import { FileSystemAdapter, FileStats, FileSystemError } from '@vue-skuilder/db';
+
+/**
+ * Node.js implementation of FileSystemAdapter using native fs and path modules.
+ * This works cleanly in CLI environments without bundling issues.
+ */
+export class NodeFileSystemAdapter implements FileSystemAdapter {
+  async readFile(filePath: string): Promise<string> {
+    try {
+      return await fs.promises.readFile(filePath, 'utf8');
+    } catch (error) {
+      throw new FileSystemError(
+        `Failed to read file: ${error instanceof Error ? error.message : String(error)}`,
+        'readFile',
+        filePath,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  async readBinary(filePath: string): Promise<Buffer> {
+    try {
+      return await fs.promises.readFile(filePath);
+    } catch (error) {
+      throw new FileSystemError(
+        `Failed to read binary file: ${error instanceof Error ? error.message : String(error)}`,
+        'readBinary',
+        filePath,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  async exists(filePath: string): Promise<boolean> {
+    try {
+      await fs.promises.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async stat(filePath: string): Promise<FileStats> {
+    try {
+      const stats = await fs.promises.stat(filePath);
+      return {
+        isDirectory: () => stats.isDirectory(),
+        isFile: () => stats.isFile(),
+        size: stats.size
+      };
+    } catch (error) {
+      throw new FileSystemError(
+        `Failed to stat file: ${error instanceof Error ? error.message : String(error)}`,
+        'stat',
+        filePath,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  joinPath(...segments: string[]): string {
+    return path.join(...segments);
+  }
+
+  isAbsolute(filePath: string): boolean {
+    return path.isAbsolute(filePath);
+  }
+}

--- a/packages/db/src/impl/couch/courseLookupDB.ts
+++ b/packages/db/src/impl/couch/courseLookupDB.ts
@@ -98,6 +98,30 @@ export default class CourseLookup {
   }
 
   /**
+   * Adds a new course to the lookup database with a specific courseID
+   * @param courseId The specific course ID to use
+   * @param courseName The course name
+   * @param disambiguator Optional disambiguator
+   * @returns Promise<void>
+   */
+  static async addWithId(
+    courseId: string, 
+    courseName: string, 
+    disambiguator?: string
+  ): Promise<void> {
+    const doc: Omit<CourseLookupDoc, '_rev'> = {
+      _id: courseId,
+      name: courseName,
+    };
+    
+    if (disambiguator) {
+      doc.disambiguator = disambiguator;
+    }
+
+    await CourseLookup._db.put(doc);
+  }
+
+  /**
    * Removes a course from the index
    * @param courseID
    */

--- a/packages/db/src/util/index.ts
+++ b/packages/db/src/util/index.ts
@@ -1,2 +1,3 @@
 export * from './Loggable';
 export * from './packer';
+export * from './migrator';

--- a/packages/db/src/util/migrator/FileSystemAdapter.ts
+++ b/packages/db/src/util/migrator/FileSystemAdapter.ts
@@ -1,0 +1,59 @@
+// packages/db/src/util/migrator/FileSystemAdapter.ts
+
+/**
+ * Abstraction for file system operations needed by the migrator.
+ * This allows dependency injection of file system operations,
+ * avoiding bundling issues with Node.js fs module.
+ */
+export interface FileSystemAdapter {
+  /**
+   * Read a text file and return its contents as a string
+   */
+  readFile(filePath: string): Promise<string>;
+
+  /**
+   * Read a binary file and return its contents as a Buffer
+   */
+  readBinary(filePath: string): Promise<Buffer>;
+
+  /**
+   * Check if a file or directory exists
+   */
+  exists(filePath: string): Promise<boolean>;
+
+  /**
+   * Get file/directory statistics
+   */
+  stat(filePath: string): Promise<FileStats>;
+
+  /**
+   * Join path segments into a complete path
+   */
+  joinPath(...segments: string[]): string;
+
+  /**
+   * Check if a path is absolute
+   */
+  isAbsolute(filePath: string): boolean;
+}
+
+export interface FileStats {
+  isDirectory(): boolean;
+  isFile(): boolean;
+  size: number;
+}
+
+/**
+ * Error thrown when file system operations fail
+ */
+export class FileSystemError extends Error {
+  constructor(
+    message: string,
+    public readonly operation: string,
+    public readonly filePath: string,
+    public readonly cause?: Error
+  ) {
+    super(message);
+    this.name = 'FileSystemError';
+  }
+}

--- a/packages/db/src/util/migrator/StaticToCouchDBMigrator.ts
+++ b/packages/db/src/util/migrator/StaticToCouchDBMigrator.ts
@@ -103,15 +103,13 @@ export class StaticToCouchDBMigrator {
       result.errors.push(...docResults.errors);
       result.warnings.push(...docResults.warnings);
 
-      // Phase 5: Upload attachments (if not skipped)
-      if (!this.options.skipAttachments) {
-        const docsWithAttachments = documents.filter(doc => doc._attachments && Object.keys(doc._attachments).length > 0);
-        this.reportProgress('attachments', 0, docsWithAttachments.length, 'Uploading attachments...');
-        const attachmentResults = await this.uploadAttachments(staticPath, docsWithAttachments, targetDB);
-        result.attachmentsRestored = attachmentResults.restored;
-        result.errors.push(...attachmentResults.errors);
-        result.warnings.push(...attachmentResults.warnings);
-      }
+      // Phase 5: Upload attachments
+      const docsWithAttachments = documents.filter(doc => doc._attachments && Object.keys(doc._attachments).length > 0);
+      this.reportProgress('attachments', 0, docsWithAttachments.length, 'Uploading attachments...');
+      const attachmentResults = await this.uploadAttachments(staticPath, docsWithAttachments, targetDB);
+      result.attachmentsRestored = attachmentResults.restored;
+      result.errors.push(...attachmentResults.errors);
+      result.warnings.push(...attachmentResults.warnings);
 
       // Phase 6: Validation (if enabled)
       if (this.options.validateRoundTrip) {
@@ -369,6 +367,7 @@ export class StaticToCouchDBMigrator {
           const cleanDoc = { ...doc };
           // Remove _rev if present (CouchDB will assign new revision)
           delete cleanDoc._rev;
+          
           return cleanDoc;
         });
 

--- a/packages/db/src/util/migrator/StaticToCouchDBMigrator.ts
+++ b/packages/db/src/util/migrator/StaticToCouchDBMigrator.ts
@@ -1,0 +1,548 @@
+// packages/db/src/util/migrator/StaticToCouchDBMigrator.ts
+
+import { logger } from '../logger';
+import { StaticCourseManifest, ChunkMetadata, DesignDocument } from '../packer/types';
+import {
+  MigrationOptions,
+  MigrationResult,
+  DEFAULT_MIGRATION_OPTIONS,
+  DocumentCounts,
+  RestoreProgress,
+  AggregatedDocument,
+  AttachmentUploadResult
+} from './types';
+import { validateStaticCourse, validateMigration } from './validation';
+
+// Check if we're in Node.js environment and fs is available
+let nodeFS: any = null;
+let nodePath: any = null;
+try {
+  if (typeof window === 'undefined' && typeof process !== 'undefined' && process.versions?.node) {
+    nodeFS = eval('require')('fs');
+    nodePath = eval('require')('path');
+    nodeFS.promises = nodeFS.promises || eval('require')('fs').promises;
+  }
+} catch {
+  // fs not available, will use fetch
+}
+
+export class StaticToCouchDBMigrator {
+  private options: MigrationOptions;
+  private progressCallback?: (progress: RestoreProgress) => void;
+
+  constructor(options: Partial<MigrationOptions> = {}) {
+    this.options = {
+      ...DEFAULT_MIGRATION_OPTIONS,
+      ...options
+    };
+  }
+
+  /**
+   * Set a progress callback to receive updates during migration
+   */
+  setProgressCallback(callback: (progress: RestoreProgress) => void): void {
+    this.progressCallback = callback;
+  }
+
+  /**
+   * Migrate a static course to CouchDB
+   */
+  async migrateCourse(
+    staticPath: string,
+    targetDB: PouchDB.Database
+  ): Promise<MigrationResult> {
+    const startTime = Date.now();
+    const result: MigrationResult = {
+      success: false,
+      documentsRestored: 0,
+      attachmentsRestored: 0,
+      designDocsRestored: 0,
+      errors: [] as string[],
+      warnings: [] as string[],
+      migrationTime: 0
+    };
+
+    try {
+      logger.info(`Starting migration from ${staticPath} to CouchDB`);
+
+      // Phase 1: Validate static course
+      this.reportProgress('manifest', 0, 1, 'Validating static course...');
+      const validation = await validateStaticCourse(staticPath);
+      if (!validation.valid) {
+        result.errors.push(...validation.errors);
+        throw new Error(`Static course validation failed: ${validation.errors.join(', ')}`);
+      }
+      result.warnings.push(...validation.warnings);
+
+      // Phase 2: Load manifest
+      this.reportProgress('manifest', 1, 1, 'Loading course manifest...');
+      const manifest = await this.loadManifest(staticPath);
+      logger.info(`Loaded manifest for course: ${manifest.courseId} (${manifest.courseName})`);
+
+      // Phase 3: Restore design documents
+      this.reportProgress('design_docs', 0, manifest.designDocs.length, 'Restoring design documents...');
+      const designDocResults = await this.restoreDesignDocuments(manifest.designDocs, targetDB);
+      result.designDocsRestored = designDocResults.restored;
+      result.errors.push(...designDocResults.errors);
+      result.warnings.push(...designDocResults.warnings);
+
+      // Phase 4: Aggregate and restore documents
+      const expectedCounts = this.calculateExpectedCounts(manifest);
+      this.reportProgress('documents', 0, manifest.documentCount, 'Aggregating documents from chunks...');
+      const documents = await this.aggregateDocuments(staticPath, manifest);
+      
+      this.reportProgress('documents', documents.length, manifest.documentCount, 'Uploading documents to CouchDB...');
+      const docResults = await this.uploadDocuments(documents, targetDB);
+      result.documentsRestored = docResults.restored;
+      result.errors.push(...docResults.errors);
+      result.warnings.push(...docResults.warnings);
+
+      // Phase 5: Upload attachments (if not skipped)
+      if (!this.options.skipAttachments) {
+        const docsWithAttachments = documents.filter(doc => doc._attachments && Object.keys(doc._attachments).length > 0);
+        this.reportProgress('attachments', 0, docsWithAttachments.length, 'Uploading attachments...');
+        const attachmentResults = await this.uploadAttachments(staticPath, docsWithAttachments, targetDB);
+        result.attachmentsRestored = attachmentResults.restored;
+        result.errors.push(...attachmentResults.errors);
+        result.warnings.push(...attachmentResults.warnings);
+      }
+
+      // Phase 6: Validation (if enabled)
+      if (this.options.validateRoundTrip) {
+        this.reportProgress('validation', 0, 1, 'Validating migration...');
+        const validationResult = await validateMigration(targetDB, expectedCounts, manifest);
+        if (!validationResult.valid) {
+          result.warnings.push('Migration validation found issues');
+          validationResult.issues.forEach(issue => {
+            if (issue.type === 'error') {
+              result.errors.push(`Validation: ${issue.message}`);
+            } else {
+              result.warnings.push(`Validation: ${issue.message}`);
+            }
+          });
+        }
+        this.reportProgress('validation', 1, 1, 'Migration validation completed');
+      }
+
+      // Success!
+      result.success = result.errors.length === 0;
+      result.migrationTime = Date.now() - startTime;
+
+      logger.info(`Migration completed in ${result.migrationTime}ms`);
+      logger.info(`Documents restored: ${result.documentsRestored}`);
+      logger.info(`Attachments restored: ${result.attachmentsRestored}`);
+      logger.info(`Design docs restored: ${result.designDocsRestored}`);
+      
+      if (result.errors.length > 0) {
+        logger.error(`Migration completed with ${result.errors.length} errors`);
+      }
+      if (result.warnings.length > 0) {
+        logger.warn(`Migration completed with ${result.warnings.length} warnings`);
+      }
+
+    } catch (error) {
+      result.success = false;
+      result.migrationTime = Date.now() - startTime;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      result.errors.push(`Migration failed: ${errorMessage}`);
+      logger.error('Migration failed:', error);
+
+      // Cleanup on failure if requested
+      if (this.options.cleanupOnFailure) {
+        try {
+          await this.cleanupFailedMigration(targetDB);
+        } catch (cleanupError) {
+          logger.error('Failed to cleanup after migration failure:', cleanupError);
+          result.warnings.push('Failed to cleanup after migration failure');
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Load and parse the manifest file
+   */
+  private async loadManifest(staticPath: string): Promise<StaticCourseManifest> {
+    const manifestPath = (nodeFS && nodePath) ? nodePath.join(staticPath, 'manifest.json') : `${staticPath}/manifest.json`;
+    
+    try {
+      let manifestContent: string;
+      
+      if (nodeFS && this.isLocalPath(staticPath)) {
+        // Node.js file system access
+        manifestContent = await nodeFS.promises.readFile(manifestPath, 'utf8');
+      } else {
+        // Browser/fetch access
+        const response = await fetch(manifestPath);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch manifest: ${response.status} ${response.statusText}`);
+        }
+        manifestContent = await response.text();
+      }
+
+      const manifest: StaticCourseManifest = JSON.parse(manifestContent);
+      
+      // Basic validation
+      if (!manifest.version || !manifest.courseId || !manifest.chunks) {
+        throw new Error('Invalid manifest structure');
+      }
+
+      return manifest;
+    } catch (error) {
+      throw new Error(`Failed to load manifest from ${manifestPath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Restore design documents to CouchDB
+   */
+  private async restoreDesignDocuments(
+    designDocs: DesignDocument[],
+    db: PouchDB.Database
+  ): Promise<{ restored: number; errors: string[]; warnings: string[] }> {
+    const result = { restored: 0, errors: [] as string[], warnings: [] as string[] };
+
+    for (let i = 0; i < designDocs.length; i++) {
+      const designDoc = designDocs[i];
+      this.reportProgress('design_docs', i, designDocs.length, `Restoring ${designDoc._id}...`);
+
+      try {
+        // Check if design document already exists
+        let existingDoc;
+        try {
+          existingDoc = await db.get(designDoc._id);
+        } catch (error) {
+          // Document doesn't exist, which is fine
+        }
+
+        // Prepare the document for insertion
+        const docToInsert: any = {
+          _id: designDoc._id,
+          views: designDoc.views
+        };
+
+        // If document exists, include the revision for update
+        if (existingDoc) {
+          docToInsert._rev = existingDoc._rev;
+          logger.debug(`Updating existing design document: ${designDoc._id}`);
+        } else {
+          logger.debug(`Creating new design document: ${designDoc._id}`);
+        }
+
+        await db.put(docToInsert);
+        result.restored++;
+
+      } catch (error) {
+        const errorMessage = `Failed to restore design document ${designDoc._id}: ${error instanceof Error ? error.message : String(error)}`;
+        result.errors.push(errorMessage);
+        logger.error(errorMessage);
+      }
+    }
+
+    this.reportProgress('design_docs', designDocs.length, designDocs.length, `Restored ${result.restored} design documents`);
+    return result;
+  }
+
+  /**
+   * Aggregate documents from all chunks
+   */
+  private async aggregateDocuments(
+    staticPath: string,
+    manifest: StaticCourseManifest
+  ): Promise<AggregatedDocument[]> {
+    const allDocuments: AggregatedDocument[] = [];
+    const documentMap = new Map<string, AggregatedDocument>(); // For deduplication
+
+    for (let i = 0; i < manifest.chunks.length; i++) {
+      const chunk = manifest.chunks[i];
+      this.reportProgress('documents', allDocuments.length, manifest.documentCount, `Loading chunk ${chunk.id}...`);
+
+      try {
+        const documents = await this.loadChunk(staticPath, chunk);
+        
+        for (const doc of documents) {
+          if (!doc._id) {
+            logger.warn(`Document without _id found in chunk ${chunk.id}, skipping`);
+            continue;
+          }
+
+          // Handle potential duplicates (shouldn't happen, but be safe)
+          if (documentMap.has(doc._id)) {
+            logger.warn(`Duplicate document ID found: ${doc._id}, using latest version`);
+          }
+
+          documentMap.set(doc._id, doc);
+        }
+
+      } catch (error) {
+        throw new Error(`Failed to load chunk ${chunk.id}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    // Convert map to array
+    allDocuments.push(...documentMap.values());
+
+    logger.info(`Aggregated ${allDocuments.length} unique documents from ${manifest.chunks.length} chunks`);
+    return allDocuments;
+  }
+
+  /**
+   * Load documents from a single chunk file
+   */
+  private async loadChunk(staticPath: string, chunk: ChunkMetadata): Promise<any[]> {
+    const chunkPath = (nodeFS && nodePath) ? nodePath.join(staticPath, chunk.path) : `${staticPath}/${chunk.path}`;
+
+    try {
+      let chunkContent: string;
+
+      if (nodeFS && this.isLocalPath(staticPath)) {
+        // Node.js file system access
+        chunkContent = await nodeFS.promises.readFile(chunkPath, 'utf8');
+      } else {
+        // Browser/fetch access
+        const response = await fetch(chunkPath);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch chunk: ${response.status} ${response.statusText}`);
+        }
+        chunkContent = await response.text();
+      }
+
+      const documents = JSON.parse(chunkContent);
+      
+      if (!Array.isArray(documents)) {
+        throw new Error('Chunk file does not contain an array of documents');
+      }
+
+      return documents;
+    } catch (error) {
+      throw new Error(`Failed to load chunk from ${chunkPath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Upload documents to CouchDB in batches
+   */
+  private async uploadDocuments(
+    documents: AggregatedDocument[],
+    db: PouchDB.Database
+  ): Promise<{ restored: number; errors: string[]; warnings: string[] }> {
+    const result = { restored: 0, errors: [] as string[], warnings: [] as string[] };
+    const batchSize = this.options.chunkBatchSize;
+
+    for (let i = 0; i < documents.length; i += batchSize) {
+      const batch = documents.slice(i, i + batchSize);
+      this.reportProgress('documents', i, documents.length, `Uploading batch ${Math.floor(i / batchSize) + 1}...`);
+
+      try {
+        // Prepare documents for bulk insert
+        const docsToInsert = batch.map(doc => {
+          const cleanDoc = { ...doc };
+          // Remove _rev if present (CouchDB will assign new revision)
+          delete cleanDoc._rev;
+          return cleanDoc;
+        });
+
+        const bulkResult = await db.bulkDocs(docsToInsert);
+
+        // Process results
+        for (let j = 0; j < bulkResult.length; j++) {
+          const docResult = bulkResult[j];
+          const originalDoc = batch[j];
+
+          if ('error' in docResult) {
+            const errorMessage = `Failed to upload document ${originalDoc._id}: ${docResult.error} - ${docResult.reason}`;
+            result.errors.push(errorMessage);
+            logger.error(errorMessage);
+          } else {
+            result.restored++;
+          }
+        }
+
+      } catch (error) {
+        const errorMessage = `Failed to upload document batch starting at index ${i}: ${error instanceof Error ? error.message : String(error)}`;
+        result.errors.push(errorMessage);
+        logger.error(errorMessage);
+      }
+    }
+
+    this.reportProgress('documents', documents.length, documents.length, `Uploaded ${result.restored} documents`);
+    return result;
+  }
+
+  /**
+   * Upload attachments from filesystem to CouchDB
+   */
+  private async uploadAttachments(
+    staticPath: string,
+    documents: AggregatedDocument[],
+    db: PouchDB.Database
+  ): Promise<{ restored: number; errors: string[]; warnings: string[] }> {
+    const result = { restored: 0, errors: [] as string[], warnings: [] as string[] };
+    let processedDocs = 0;
+
+    for (const doc of documents) {
+      this.reportProgress('attachments', processedDocs, documents.length, `Processing attachments for ${doc._id}...`);
+      processedDocs++;
+
+      if (!doc._attachments) {
+        continue;
+      }
+
+      for (const [attachmentName, attachmentMeta] of Object.entries(doc._attachments)) {
+        try {
+          const uploadResult = await this.uploadSingleAttachment(
+            staticPath,
+            doc._id,
+            attachmentName,
+            attachmentMeta as any,
+            db
+          );
+
+          if (uploadResult.success) {
+            result.restored++;
+          } else {
+            result.errors.push(uploadResult.error || 'Unknown attachment upload error');
+          }
+
+        } catch (error) {
+          const errorMessage = `Failed to upload attachment ${doc._id}/${attachmentName}: ${error instanceof Error ? error.message : String(error)}`;
+          result.errors.push(errorMessage);
+          logger.error(errorMessage);
+        }
+      }
+    }
+
+    this.reportProgress('attachments', documents.length, documents.length, `Uploaded ${result.restored} attachments`);
+    return result;
+  }
+
+  /**
+   * Upload a single attachment file
+   */
+  private async uploadSingleAttachment(
+    staticPath: string,
+    docId: string,
+    attachmentName: string,
+    attachmentMeta: any,
+    db: PouchDB.Database
+  ): Promise<AttachmentUploadResult> {
+    const result: AttachmentUploadResult = {
+      success: false,
+      attachmentName,
+      docId
+    };
+
+    try {
+      // Get the file path from the attachment metadata
+      if (!attachmentMeta.path) {
+        result.error = 'Attachment metadata missing file path';
+        return result;
+      }
+
+      const attachmentPath = (nodeFS && nodePath) ? nodePath.join(staticPath, attachmentMeta.path) : `${staticPath}/${attachmentMeta.path}`;
+
+      // Load the attachment data
+      let attachmentData: ArrayBuffer | Buffer;
+
+      if (nodeFS && this.isLocalPath(staticPath)) {
+        // Node.js file system access
+        attachmentData = await nodeFS.promises.readFile(attachmentPath);
+      } else {
+        // Browser/fetch access
+        const response = await fetch(attachmentPath);
+        if (!response.ok) {
+          result.error = `Failed to fetch attachment: ${response.status} ${response.statusText}`;
+          return result;
+        }
+        attachmentData = await response.arrayBuffer();
+      }
+
+      // Upload to CouchDB
+      await db.putAttachment(
+        docId,
+        attachmentName,
+        attachmentData as any, // PouchDB accepts both ArrayBuffer and Buffer
+        attachmentMeta.content_type
+      );
+
+      result.success = true;
+
+    } catch (error) {
+      result.error = error instanceof Error ? error.message : String(error);
+    }
+
+    return result;
+  }
+
+  /**
+   * Calculate expected document counts from manifest
+   */
+  private calculateExpectedCounts(manifest: StaticCourseManifest): DocumentCounts {
+    const counts: DocumentCounts = {};
+
+    // Count documents by type from chunks
+    for (const chunk of manifest.chunks) {
+      counts[chunk.docType] = (counts[chunk.docType] || 0) + chunk.documentCount;
+    }
+
+    // Count design documents
+    if (manifest.designDocs.length > 0) {
+      counts['_design'] = manifest.designDocs.length;
+    }
+
+    return counts;
+  }
+
+  /**
+   * Clean up database after failed migration
+   */
+  private async cleanupFailedMigration(db: PouchDB.Database): Promise<void> {
+    logger.info('Cleaning up failed migration...');
+
+    try {
+      // Get all documents and delete them
+      const allDocs = await db.allDocs();
+      const docsToDelete = allDocs.rows.map(row => ({
+        _id: row.id,
+        _rev: row.value.rev,
+        _deleted: true
+      }));
+
+      if (docsToDelete.length > 0) {
+        await db.bulkDocs(docsToDelete);
+        logger.info(`Cleaned up ${docsToDelete.length} documents from failed migration`);
+      }
+    } catch (error) {
+      logger.error('Failed to cleanup documents:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Report progress to callback if available
+   */
+  private reportProgress(
+    phase: RestoreProgress['phase'],
+    current: number,
+    total: number,
+    message: string
+  ): void {
+    if (this.progressCallback) {
+      this.progressCallback({
+        phase,
+        current,
+        total,
+        message
+      });
+    }
+  }
+
+  /**
+   * Check if a path is a local file path (vs URL)
+   */
+  private isLocalPath(path: string): boolean {
+    return !path.startsWith('http://') && !path.startsWith('https://');
+  }
+}

--- a/packages/db/src/util/migrator/index.ts
+++ b/packages/db/src/util/migrator/index.ts
@@ -1,0 +1,16 @@
+// packages/db/src/util/migrator/index.ts
+
+export { StaticToCouchDBMigrator } from './StaticToCouchDBMigrator';
+export { validateStaticCourse, validateMigration } from './validation';
+export type {
+  MigrationOptions,
+  MigrationResult,
+  ValidationResult,
+  ValidationIssue,
+  DocumentCounts,
+  RestoreProgress,
+  StaticCourseValidation,
+  AggregatedDocument,
+  AttachmentUploadResult,
+  DEFAULT_MIGRATION_OPTIONS
+} from './types';

--- a/packages/db/src/util/migrator/index.ts
+++ b/packages/db/src/util/migrator/index.ts
@@ -2,6 +2,7 @@
 
 export { StaticToCouchDBMigrator } from './StaticToCouchDBMigrator';
 export { validateStaticCourse, validateMigration } from './validation';
+export { FileSystemAdapter, FileStats, FileSystemError } from './FileSystemAdapter';
 export type {
   MigrationOptions,
   MigrationResult,

--- a/packages/db/src/util/migrator/index.ts
+++ b/packages/db/src/util/migrator/index.ts
@@ -2,7 +2,8 @@
 
 export { StaticToCouchDBMigrator } from './StaticToCouchDBMigrator';
 export { validateStaticCourse, validateMigration } from './validation';
-export { FileSystemAdapter, FileStats, FileSystemError } from './FileSystemAdapter';
+export type { FileSystemAdapter, FileStats } from './FileSystemAdapter';
+export { FileSystemError } from './FileSystemAdapter';
 export type {
   MigrationOptions,
   MigrationResult,

--- a/packages/db/src/util/migrator/types.ts
+++ b/packages/db/src/util/migrator/types.ts
@@ -2,7 +2,6 @@
 
 export interface MigrationOptions {
   chunkBatchSize: number;
-  skipAttachments: boolean;
   validateRoundTrip: boolean;
   cleanupOnFailure: boolean;
   timeout: number; // milliseconds
@@ -72,7 +71,6 @@ export interface AttachmentUploadResult {
 
 export const DEFAULT_MIGRATION_OPTIONS: MigrationOptions = {
   chunkBatchSize: 100,
-  skipAttachments: false,
   validateRoundTrip: false,
   cleanupOnFailure: true,
   timeout: 300000, // 5 minutes

--- a/packages/db/src/util/migrator/types.ts
+++ b/packages/db/src/util/migrator/types.ts
@@ -1,0 +1,79 @@
+// packages/db/src/util/migrator/types.ts
+
+export interface MigrationOptions {
+  chunkBatchSize: number;
+  skipAttachments: boolean;
+  validateRoundTrip: boolean;
+  cleanupOnFailure: boolean;
+  timeout: number; // milliseconds
+}
+
+export interface MigrationResult {
+  success: boolean;
+  documentsRestored: number;
+  attachmentsRestored: number;
+  designDocsRestored: number;
+  errors: string[];
+  warnings: string[];
+  migrationTime: number;
+  tempDatabaseName?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  documentCountMatch: boolean;
+  attachmentIntegrity: boolean;
+  viewFunctionality: boolean;
+  issues: ValidationIssue[];
+}
+
+export interface ValidationIssue {
+  type: 'error' | 'warning';
+  category: 'documents' | 'attachments' | 'views' | 'metadata';
+  message: string;
+  details?: any;
+}
+
+export interface DocumentCounts {
+  [docType: string]: number;
+}
+
+export interface RestoreProgress {
+  phase: 'manifest' | 'design_docs' | 'documents' | 'attachments' | 'validation';
+  current: number;
+  total: number;
+  message: string;
+}
+
+export interface StaticCourseValidation {
+  valid: boolean;
+  manifestExists: boolean;
+  chunksExist: boolean;
+  attachmentsExist: boolean;
+  errors: string[];
+  warnings: string[];
+  courseId?: string;
+  courseName?: string;
+}
+
+export interface AggregatedDocument {
+  _id: string;
+  _attachments?: Record<string, any>;
+  docType: string;
+  [key: string]: any;
+}
+
+export interface AttachmentUploadResult {
+  success: boolean;
+  attachmentName: string;
+  docId: string;
+  error?: string;
+}
+
+export const DEFAULT_MIGRATION_OPTIONS: MigrationOptions = {
+  chunkBatchSize: 100,
+  skipAttachments: false,
+  validateRoundTrip: false,
+  cleanupOnFailure: true,
+  timeout: 300000, // 5 minutes
+};

--- a/packages/db/src/util/migrator/types.ts
+++ b/packages/db/src/util/migrator/types.ts
@@ -12,6 +12,7 @@ export interface MigrationResult {
   documentsRestored: number;
   attachmentsRestored: number;
   designDocsRestored: number;
+  courseConfigRestored: number;
   errors: string[];
   warnings: string[];
   migrationTime: number;
@@ -28,7 +29,7 @@ export interface ValidationResult {
 
 export interface ValidationIssue {
   type: 'error' | 'warning';
-  category: 'documents' | 'attachments' | 'views' | 'metadata';
+  category: 'documents' | 'attachments' | 'views' | 'metadata' | 'course_config';
   message: string;
   details?: any;
 }
@@ -38,7 +39,7 @@ export interface DocumentCounts {
 }
 
 export interface RestoreProgress {
-  phase: 'manifest' | 'design_docs' | 'documents' | 'attachments' | 'validation';
+  phase: 'manifest' | 'design_docs' | 'course_config' | 'documents' | 'attachments' | 'validation';
   current: number;
   total: number;
   message: string;
@@ -60,6 +61,12 @@ export interface AggregatedDocument {
   _attachments?: Record<string, any>;
   docType: string;
   [key: string]: any;
+}
+
+export interface RestoreResults {
+  restored: number;
+  errors: string[];
+  warnings: string[];
 }
 
 export interface AttachmentUploadResult {

--- a/packages/db/src/util/migrator/validation.ts
+++ b/packages/db/src/util/migrator/validation.ts
@@ -1,0 +1,366 @@
+// packages/db/src/util/migrator/validation.ts
+
+import { logger } from '../logger';
+import { StaticCourseValidation, ValidationResult, DocumentCounts, ValidationIssue } from './types';
+import { StaticCourseManifest } from '../packer/types';
+
+// Check if we're in Node.js environment and fs is available
+let nodeFS: any = null;
+try {
+  if (typeof window === 'undefined' && typeof process !== 'undefined' && process.versions?.node) {
+    nodeFS = eval('require')('fs');
+    nodeFS.promises = nodeFS.promises || eval('require')('fs').promises;
+  }
+} catch {
+  // fs not available
+}
+
+/**
+ * Validate that a static course directory contains all required files
+ */
+export async function validateStaticCourse(staticPath: string): Promise<StaticCourseValidation> {
+  const validation: StaticCourseValidation = {
+    valid: true,
+    manifestExists: false,
+    chunksExist: false,
+    attachmentsExist: false,
+    errors: [],
+    warnings: [],
+  };
+
+  try {
+    // Check if path exists and is directory
+    if (!nodeFS) {
+      validation.errors.push('File system access not available - validation skipped');
+      validation.valid = false;
+      return validation;
+    }
+
+    const stats = await nodeFS.promises.stat(staticPath);
+    if (!stats.isDirectory()) {
+      validation.errors.push(`Path is not a directory: ${staticPath}`);
+      validation.valid = false;
+      return validation;
+    }
+
+    // Check for manifest.json
+    const manifestPath = `${staticPath}/manifest.json`;
+    try {
+      await nodeFS.promises.access(manifestPath);
+      validation.manifestExists = true;
+
+      // Parse manifest to get course info
+      const manifestContent = await nodeFS.promises.readFile(manifestPath, 'utf8');
+      const manifest: StaticCourseManifest = JSON.parse(manifestContent);
+      validation.courseId = manifest.courseId;
+      validation.courseName = manifest.courseName;
+
+      // Validate manifest structure
+      if (
+        !manifest.version ||
+        !manifest.courseId ||
+        !manifest.chunks ||
+        !Array.isArray(manifest.chunks)
+      ) {
+        validation.errors.push('Invalid manifest structure');
+        validation.valid = false;
+      }
+    } catch (error) {
+      validation.errors.push(`Manifest not found or invalid: ${manifestPath}`);
+      validation.valid = false;
+    }
+
+    // Check for chunks directory
+    const chunksPath = `${staticPath}/chunks`;
+    try {
+      const chunksStats = await nodeFS.promises.stat(chunksPath);
+      if (chunksStats.isDirectory()) {
+        validation.chunksExist = true;
+      } else {
+        validation.errors.push(`Chunks path is not a directory: ${chunksPath}`);
+        validation.valid = false;
+      }
+    } catch (error) {
+      validation.errors.push(`Chunks directory not found: ${chunksPath}`);
+      validation.valid = false;
+    }
+
+    // Check for attachments directory (optional - course might not have attachments)
+    const attachmentsPath = `${staticPath}/attachments`;
+    try {
+      const attachmentsStats = await nodeFS.promises.stat(attachmentsPath);
+      if (attachmentsStats.isDirectory()) {
+        validation.attachmentsExist = true;
+      }
+    } catch (error) {
+      // Attachments directory is optional
+      validation.warnings.push(
+        `Attachments directory not found: ${attachmentsPath} (this is OK if course has no attachments)`
+      );
+    }
+  } catch (error) {
+    validation.errors.push(
+      `Failed to validate static course: ${error instanceof Error ? error.message : String(error)}`
+    );
+    validation.valid = false;
+  }
+
+  return validation;
+}
+
+/**
+ * Validate the result of a migration by checking document counts and integrity
+ */
+export async function validateMigration(
+  targetDB: PouchDB.Database,
+  expectedCounts: DocumentCounts,
+  manifest: StaticCourseManifest
+): Promise<ValidationResult> {
+  const validation: ValidationResult = {
+    valid: true,
+    documentCountMatch: false,
+    attachmentIntegrity: false,
+    viewFunctionality: false,
+    issues: [],
+  };
+
+  try {
+    logger.info('Starting migration validation...');
+
+    // 1. Validate document counts
+    const actualCounts = await getActualDocumentCounts(targetDB);
+    validation.documentCountMatch = compareDocumentCounts(
+      expectedCounts,
+      actualCounts,
+      validation.issues
+    );
+
+    // 2. Validate design documents and views
+    validation.viewFunctionality = await validateViews(targetDB, manifest, validation.issues);
+
+    // 3. Validate attachment integrity (sample check)
+    validation.attachmentIntegrity = await validateAttachmentIntegrity(targetDB, validation.issues);
+
+    // Overall validation result
+    validation.valid =
+      validation.documentCountMatch &&
+      validation.viewFunctionality &&
+      validation.attachmentIntegrity;
+
+    logger.info(`Migration validation completed. Valid: ${validation.valid}`);
+    if (validation.issues.length > 0) {
+      logger.info(`Validation issues: ${validation.issues.length}`);
+      validation.issues.forEach((issue) => {
+        if (issue.type === 'error') {
+          logger.error(`${issue.category}: ${issue.message}`);
+        } else {
+          logger.warn(`${issue.category}: ${issue.message}`);
+        }
+      });
+    }
+  } catch (error) {
+    validation.valid = false;
+    validation.issues.push({
+      type: 'error',
+      category: 'metadata',
+      message: `Validation failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+
+  return validation;
+}
+
+/**
+ * Get actual document counts by type from the database
+ */
+async function getActualDocumentCounts(db: PouchDB.Database): Promise<DocumentCounts> {
+  const counts: DocumentCounts = {};
+
+  try {
+    const allDocs = await db.allDocs({ include_docs: true });
+
+    for (const row of allDocs.rows) {
+      if (row.id.startsWith('_design/')) {
+        // Count design documents separately
+        counts['_design'] = (counts['_design'] || 0) + 1;
+        continue;
+      }
+
+      const doc = row.doc as any;
+      if (doc && doc.docType) {
+        counts[doc.docType] = (counts[doc.docType] || 0) + 1;
+      } else {
+        // Documents without docType
+        counts['unknown'] = (counts['unknown'] || 0) + 1;
+      }
+    }
+  } catch (error) {
+    logger.error('Failed to get actual document counts:', error);
+  }
+
+  return counts;
+}
+
+/**
+ * Compare expected vs actual document counts
+ */
+function compareDocumentCounts(
+  expected: DocumentCounts,
+  actual: DocumentCounts,
+  issues: ValidationIssue[]
+): boolean {
+  let countsMatch = true;
+
+  // Check each expected document type
+  for (const [docType, expectedCount] of Object.entries(expected)) {
+    const actualCount = actual[docType] || 0;
+
+    if (actualCount !== expectedCount) {
+      countsMatch = false;
+      issues.push({
+        type: 'error',
+        category: 'documents',
+        message: `Document count mismatch for ${docType}: expected ${expectedCount}, got ${actualCount}`,
+      });
+    }
+  }
+
+  // Check for unexpected document types
+  for (const [docType, actualCount] of Object.entries(actual)) {
+    if (!expected[docType] && docType !== '_design') {
+      issues.push({
+        type: 'warning',
+        category: 'documents',
+        message: `Unexpected document type found: ${docType} (${actualCount} documents)`,
+      });
+    }
+  }
+
+  return countsMatch;
+}
+
+/**
+ * Validate that design documents and views are working correctly
+ */
+async function validateViews(
+  db: PouchDB.Database,
+  manifest: StaticCourseManifest,
+  issues: ValidationIssue[]
+): Promise<boolean> {
+  let viewsValid = true;
+
+  try {
+    // Check that design documents exist
+    for (const designDoc of manifest.designDocs) {
+      try {
+        const doc = await db.get(designDoc._id);
+        if (!doc) {
+          viewsValid = false;
+          issues.push({
+            type: 'error',
+            category: 'views',
+            message: `Design document not found: ${designDoc._id}`,
+          });
+          continue;
+        }
+
+        // Test each view in the design document
+        for (const viewName of Object.keys(designDoc.views)) {
+          try {
+            const viewPath = `${designDoc._id}/${viewName}`;
+            await db.query(viewPath, { limit: 1 });
+            // If we get here, the view is accessible (even if it returns no results)
+          } catch (viewError) {
+            viewsValid = false;
+            issues.push({
+              type: 'error',
+              category: 'views',
+              message: `View not accessible: ${designDoc._id}/${viewName} - ${viewError}`,
+            });
+          }
+        }
+      } catch (error) {
+        viewsValid = false;
+        issues.push({
+          type: 'error',
+          category: 'views',
+          message: `Failed to validate design document ${designDoc._id}: ${error}`,
+        });
+      }
+    }
+  } catch (error) {
+    viewsValid = false;
+    issues.push({
+      type: 'error',
+      category: 'views',
+      message: `View validation failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+
+  return viewsValid;
+}
+
+/**
+ * Validate attachment integrity by checking a sample of attachments
+ */
+async function validateAttachmentIntegrity(
+  db: PouchDB.Database,
+  issues: ValidationIssue[]
+): Promise<boolean> {
+  let attachmentsValid = true;
+
+  try {
+    // Get documents with attachments (sample check)
+    const allDocs = await db.allDocs({
+      include_docs: true,
+      limit: 10, // Sample first 10 documents for performance
+    });
+
+    let attachmentCount = 0;
+    let validAttachments = 0;
+
+    for (const row of allDocs.rows) {
+      const doc = row.doc as any;
+      if (doc && doc._attachments) {
+        for (const [attachmentName, _attachmentMeta] of Object.entries(doc._attachments)) {
+          attachmentCount++;
+
+          try {
+            // Try to access the attachment
+            const attachment = await db.getAttachment(doc._id, attachmentName);
+            if (attachment) {
+              validAttachments++;
+            }
+          } catch (attachmentError) {
+            attachmentsValid = false;
+            issues.push({
+              type: 'error',
+              category: 'attachments',
+              message: `Attachment not accessible: ${doc._id}/${attachmentName} - ${attachmentError}`,
+            });
+          }
+        }
+      }
+    }
+
+    if (attachmentCount === 0) {
+      // No attachments found - this is OK
+      issues.push({
+        type: 'warning',
+        category: 'attachments',
+        message: 'No attachments found in sampled documents',
+      });
+    } else {
+      logger.info(`Validated ${validAttachments}/${attachmentCount} sampled attachments`);
+    }
+  } catch (error) {
+    attachmentsValid = false;
+    issues.push({
+      type: 'error',
+      category: 'attachments',
+      message: `Attachment validation failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+
+  return attachmentsValid;
+}


### PR DESCRIPTION
Toward #791, related to #718. PR adds an `unpack` command to the cli that reverses the `pack` command - taking a json+files encoded course and migrating it to a live couchdb 

This will integrate with, especially, the standalone-ui doing static-course development (eg, via `cli init`) in order to provide an editing `studio` for packed json data.

- **(wip) unpacker - static json crs data -> couchdb**
- **add unpack cmd to cli**
