### PR TITLE
[StudySession.vue] DocumentUpdateConflict fix

### DIFF
--- a/packages/common-ui/src/components/StudySession.vue
+++ b/packages/common-ui/src/components/StudySession.vue
@@ -422,6 +422,7 @@ export default defineComponent({
             this.loadCard(this.sessionController!.nextCard('marked-failed'));
           }
         } else {
+          /* !r.isCorrect */
           try {
             if (this.$refs.shadowWrapper) {
               this.$refs.shadowWrapper.classList.add('incorrect');

--- a/packages/db/src/impl/couch/updateQueue.ts
+++ b/packages/db/src/impl/couch/updateQueue.ts
@@ -105,6 +105,8 @@ export default class UpdateQueue extends Loggable {
             }
           }
         }
+        // This should be unreachable, but it satisfies the compiler that a value is always returned or an error thrown.
+        throw new Error(`UpdateQueue failed for doc ${id} after ${MAX_RETRIES} retries.`);
       } else {
         throw new Error(`Empty Updates Queue Triggered`);
       }


### PR DESCRIPTION
Updates to cardHistory documents were frequently failing (and not obviously being retried or eventually succeeding).

PR adds basic retry logic to the updateQ, which should either fix the issue or provide better insight.

- **label else branch**
- **add retry logic for updateQ**
