### PR TITLE
refactor: begin deprecating qualifiedID for cards

### DIFF
--- a/packages/db/src/core/interfaces/contentSource.ts
+++ b/packages/db/src/core/interfaces/contentSource.ts
@@ -31,11 +31,12 @@ export function isReview(item: StudySessionItem): item is StudySessionReviewItem
 
 export interface StudySessionItem {
   status: 'new' | 'review' | 'failed-new' | 'failed-review';
-  qualifiedID: `${string}-${string}` | `${string}-${string}-${number}`;
-  cardID: string;
   contentSourceType: 'course' | 'classroom';
   contentSourceID: string;
+  // qualifiedID: `${string}-${string}` | `${string}-${string}-${number}`;
+  cardID: string;
   courseID: string;
+  elo?: number;
   // reviewID?: string;
 }
 

--- a/packages/db/src/core/interfaces/courseDB.ts
+++ b/packages/db/src/core/interfaces/courseDB.ts
@@ -53,7 +53,16 @@ export interface CourseDBInterface extends NavigationStrategyManager {
   /**
    * Get cards sorted by ELO rating
    */
-  getCardsByELO(elo: number, limit?: number): Promise<string[]>;
+  getCardsByELO(
+    elo: number,
+    limit?: number
+  ): Promise<
+    {
+      courseID: string;
+      cardID: string;
+      elo?: number;
+    }[]
+  >;
 
   /**
    * Get ELO data for specific cards
@@ -145,7 +154,7 @@ export interface CourseDBInterface extends NavigationStrategyManager {
   searchCards(query: string): Promise<any[]>;
 
   /**
-   * Find documents using PouchDB query syntax  
+   * Find documents using PouchDB query syntax
    * @param request PouchDB find request
    * @returns Query response
    */

--- a/packages/db/src/impl/couch/classroomDB.ts
+++ b/packages/db/src/impl/couch/classroomDB.ts
@@ -8,12 +8,7 @@ import { ENV } from '@db/factory';
 import { logger } from '@db/util/logger';
 import moment from 'moment';
 import pouch from './pouchdb-setup';
-import {
-  getCourseDB,
-  getStartAndEndKeys,
-  createPouchDBConfig,
-  REVIEW_TIME_FORMAT,
-} from '.';
+import { getCourseDB, getStartAndEndKeys, createPouchDBConfig, REVIEW_TIME_FORMAT } from '.';
 import { CourseDB, getTag } from './courseDB';
 
 import { UserDBInterface } from '@db/core';
@@ -181,10 +176,13 @@ export class StudentClassroomDB
       }
     }
 
-    logger.info(`New Cards from classroom ${this._cfg.name}: ${ret.map((c) => c.qualifiedID)}`);
+    logger.info(
+      `New Cards from classroom ${this._cfg.name}: ${ret.map((c) => `${c.courseID}-${c.cardID}`)}`
+    );
 
     return ret.filter((c) => {
-      if (activeCards.some((ac) => c.qualifiedID.includes(ac))) {
+      if (activeCards.some((ac) => c.cardID.includes(ac))) {
+        // [ ] almost certainly broken after removing qualifiedID from StudySessionItem
         return false;
       } else {
         return true;

--- a/packages/db/src/impl/static/courseDB.ts
+++ b/packages/db/src/impl/static/courseDB.ts
@@ -91,8 +91,20 @@ export class StaticCourseDB implements CourseDBInterface {
     };
   }
 
-  async getCardsByELO(elo: number, limit?: number): Promise<string[]> {
-    return this.unpacker.queryByElo(elo, limit || 25);
+  async getCardsByELO(
+    elo: number,
+    limit?: number
+  ): Promise<
+    {
+      courseID: string;
+      cardID: string;
+      elo?: number;
+    }[]
+  > {
+    return (await this.unpacker.queryByElo(elo, limit || 25)).map((card) => {
+      const [courseID, cardID, elo] = card.split('-');
+      return { courseID, cardID, elo: elo ? parseInt(elo) : undefined };
+    });
   }
 
   async getCardEloData(cardIds: string[]): Promise<CourseElo[]> {
@@ -403,7 +415,7 @@ export class StaticCourseDB implements CourseDBInterface {
     // Could be implemented with local search if needed
     return {
       docs: [],
-      warning: 'Find operations not supported in static mode'
+      warning: 'Find operations not supported in static mode',
     } as any;
   }
 }

--- a/packages/db/src/study/SessionController.ts
+++ b/packages/db/src/study/SessionController.ts
@@ -62,7 +62,8 @@ class ItemQueue<T extends StudySessionItem> {
 
   public get toString(): string {
     return (
-      `${typeof this.q[0]}:\n` + this.q.map((i) => `\t${i.qualifiedID}: ${i.status}`).join('\n')
+      `${typeof this.q[0]}:\n` +
+      this.q.map((i) => `\t${i.courseID}+${i.cardID}: ${i.status}`).join('\n')
     );
   }
 }
@@ -224,7 +225,7 @@ export class SessionController extends Loggable {
     for (let i = 0; i < dueCards.length; i++) {
       const card = dueCards[i];
       this.reviewQ.add(card);
-      report += `\t${card.qualifiedID}}\n`;
+      report += `\t${card.courseID}-${card.cardID}\n`;
     }
     this.log(report);
   }
@@ -244,7 +245,7 @@ export class SessionController extends Loggable {
       for (let i = 0; i < newContent.length; i++) {
         if (newContent[i].length > 0) {
           const item = newContent[i].splice(0, 1)[0];
-          this.log(`Adding new card: ${item.qualifiedID}`);
+          this.log(`Adding new card: ${item.courseID}-${item.cardID}`); // revealed bug here w/ new prefixes.  osbserved log "Adding new card: 5e627b7f630998243834152aa00920f5-c"
           this.newQ.add(item);
           n--;
         }
@@ -264,6 +265,7 @@ export class SessionController extends Loggable {
   }
 
   public nextCard(
+    // [ ] this is often slow. Why?
     action:
       | 'dismiss-success'
       | 'dismiss-failed'
@@ -373,7 +375,6 @@ export class SessionController extends Loggable {
           failedItem = {
             cardID: this._currentCard.cardID,
             courseID: this._currentCard.courseID,
-            qualifiedID: this._currentCard.qualifiedID,
             contentSourceID: this._currentCard.contentSourceID,
             contentSourceType: this._currentCard.contentSourceType,
             status: 'failed-review',
@@ -383,7 +384,6 @@ export class SessionController extends Loggable {
           failedItem = {
             cardID: this._currentCard.cardID,
             courseID: this._currentCard.courseID,
-            qualifiedID: this._currentCard.qualifiedID,
             contentSourceID: this._currentCard.contentSourceID,
             contentSourceType: this._currentCard.contentSourceType,
             status: 'failed-new',

--- a/packages/mcp/src/resources/shapes.ts
+++ b/packages/mcp/src/resources/shapes.ts
@@ -82,9 +82,9 @@ export async function handleShapeSpecificResource(
     let examples: any[] = [];
     try {
       // Get a few cards that use this shape to provide examples
-      const cardIds = await courseDB.getCardsByELO(1500, 10); // Get some sample cards
-      if (cardIds.length > 0) {
-        const cardDocs = await courseDB.getCourseDocs(cardIds.slice(0, 5)); // Limit to 5 examples
+      const cards = await courseDB.getCardsByELO(1500, 10); // Get some sample cards
+      if (cards.length > 0) {
+        const cardDocs = await courseDB.getCourseDocs(cards.map(c=>c.cardID).slice(0, 5)); // Limit to 5 examples
         examples = [];
         for (const row of cardDocs.rows) {
           if (isSuccessRow(row) && (row.doc as any).shape?.name === shapeName) {


### PR DESCRIPTION
error prone manual string manipulation. Broke after cards given `c-{id}`
prefix.

replacing in-place now w/ structured represnetation (object) of same
data
